### PR TITLE
Mobilewallet updates including fix for 21 errors when compiling

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - CryptoSwift (0.12.0)
+  - CryptoSwift (0.13.0)
   - MBProgressHUD (1.1.0)
   - PasswordStrength (0.1.0)
-  - QRCodeReader.swift (8.2.0)
+  - QRCodeReader.swift (9.0.1)
   - SlideMenuControllerSwift (4.0.0)
 
 DEPENDENCIES:
@@ -21,12 +21,12 @@ SPEC REPOS:
     - SlideMenuControllerSwift
 
 SPEC CHECKSUMS:
-  CryptoSwift: 1c07ca50843dd48bc54e6ea53d7a4dba3b645716
+  CryptoSwift: 16e78bebf567bad1c87b2d58f6547f25b74c31aa
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
   PasswordStrength: bf426361d758a89824d056c9fb46c48476289ff9
-  QRCodeReader.swift: 003eb32f18a5a675b936ec82ba0ff368cddbff45
+  QRCodeReader.swift: 96292a5612fbc2fd9a0b26f93fa5164c8d02f59d
   SlideMenuControllerSwift: 021d6318201c53d4d4d3710517d43d6c556c7dd0
 
 PODFILE CHECKSUM: ba12d92659a480dbe028c8fb1679a6a86d052c3c
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.5.2

--- a/decred_wallet.xcodeproj/project.pbxproj
+++ b/decred_wallet.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		B853136BC96255F028D8CB64 /* Pods_Decred_Wallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD1BD0208F6C9A0051F58F /* Pods_Decred_Wallet.framework */; };
 		DD0B356E218930B7000830C4 /* AddAcountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0B356D218930B7000830C4 /* AddAcountViewController.swift */; };
 		DD0C493E208A160900986C6B /* WalletSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0C493D208A160900986C6B /* WalletSetupViewController.swift */; };
-		DD15867721A803D40086DB44 /* Mobilewallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD15867621A803D40086DB44 /* Mobilewallet.framework */; };
+		DD1A0C7921B33CA900EA03B6 /* Mobilewallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1A0C7821B33CA900EA03B6 /* Mobilewallet.framework */; };
 		DD1D5C7C20AED828009789DD /* certificateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1D5C7B20AED824009789DD /* certificateViewController.swift */; };
 		DD1D5C7E20AEDB15009789DD /* WalletLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1D5C7D20AEDB15009789DD /* WalletLogViewController.swift */; };
 		DD1D5C8020AEDB2B009789DD /* NodeLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1D5C7F20AEDB2B009789DD /* NodeLogViewController.swift */; };
@@ -200,7 +200,7 @@
 		A1A97C56BC75512DA55A8A70 /* Pods-Decred WalletTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred WalletTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Decred WalletTests/Pods-Decred WalletTests.release.xcconfig"; sourceTree = "<group>"; };
 		DD0B356D218930B7000830C4 /* AddAcountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddAcountViewController.swift; path = view_controller/AddAcountViewController.swift; sourceTree = "<group>"; };
 		DD0C493D208A160900986C6B /* WalletSetupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSetupViewController.swift; sourceTree = "<group>"; };
-		DD15867621A803D40086DB44 /* Mobilewallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mobilewallet.framework; sourceTree = "<group>"; };
+		DD1A0C7821B33CA900EA03B6 /* Mobilewallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mobilewallet.framework; sourceTree = "<group>"; };
 		DD1D5C7B20AED824009789DD /* certificateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = certificateViewController.swift; sourceTree = "<group>"; };
 		DD1D5C7D20AEDB15009789DD /* WalletLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogViewController.swift; sourceTree = "<group>"; };
 		DD1D5C7F20AEDB2B009789DD /* NodeLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeLogViewController.swift; sourceTree = "<group>"; };
@@ -251,7 +251,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1E3D73D7EA02D2D2D3CD052C /* Pods_Decred_Wallet.framework in Frameworks */,
-				DD15867721A803D40086DB44 /* Mobilewallet.framework in Frameworks */,
+				DD1A0C7921B33CA900EA03B6 /* Mobilewallet.framework in Frameworks */,
 				B853136BC96255F028D8CB64 /* Pods_Decred_Wallet.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -340,7 +340,7 @@
 		5300E0A95A9FA022A08F903E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DD15867621A803D40086DB44 /* Mobilewallet.framework */,
+				DD1A0C7821B33CA900EA03B6 /* Mobilewallet.framework */,
 				28FD1BD0208F6C9A0051F58F /* Pods_Decred_Wallet.framework */,
 				28FD1BC5208E667F0051F58F /* Pods_Decred_Wallet.framework */,
 				28FD1BC1208E659A0051F58F /* Pods_Decred_Wallet.framework */,
@@ -970,7 +970,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = KQ46EWSK84;
+				DEVELOPMENT_TEAM = LYZ95J7356;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -982,7 +982,7 @@
 				INFOPLIST_FILE = decred_wallet/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.ensoreus.DecredWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.macsleven.DecredWallet;
 				PRODUCT_NAME = DecredWallet;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1003,7 +1003,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = KQ46EWSK84;
+				DEVELOPMENT_TEAM = LYZ95J7356;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1015,7 +1015,7 @@
 				INFOPLIST_FILE = decred_wallet/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.ensoreus.DecredWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.macsleven.DecredWallet;
 				PRODUCT_NAME = DecredWallet;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/decred_wallet/AppDelegate.swift
+++ b/decred_wallet/AppDelegate.swift
@@ -51,10 +51,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     fileprivate func populateFirstScreen() {
         if isWalletCreated() {
-            SingleInstance.shared.wallet = MobilewalletNewLibWallet(NSHomeDirectory() + "/Documents/dcrwallet/", "bdb")
+            SingleInstance.shared.wallet = MobilewalletNewLibWallet(NSHomeDirectory() + "/Documents/dcrwallet/", "bdb", "testnet3")
             SingleInstance.shared.wallet?.initLoader()
+            let key = "public"
+            let finalkey = key as NSString
+            let finalkeyData = finalkey.data(using: String.Encoding.utf8.rawValue)!
             do {
-                ((try SingleInstance.shared.wallet?.open()))
+                ((try SingleInstance.shared.wallet?.open(finalkeyData)))
             } catch let error {
                 print(error)
             }
@@ -63,7 +66,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             
         } else {
-            SingleInstance.shared.wallet = MobilewalletNewLibWallet(NSHomeDirectory() + "/Documents/dcrwallet/", "bdb")
+            SingleInstance.shared.wallet = MobilewalletNewLibWallet(NSHomeDirectory() + "/Documents/dcrwallet/", "bdb", "testnet3")
             SingleInstance.shared.wallet?.initLoader()
            DispatchQueue.global(qos: .default).async {
             self.walletSetupView()
@@ -141,9 +144,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
     func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
-        if(SingleInstance.shared.wallet != nil){
-            SingleInstance.shared.wallet?.runGC()
-        }
     }
 }
 

--- a/decred_wallet/view_controller/AddAcountViewController.swift
+++ b/decred_wallet/view_controller/AddAcountViewController.swift
@@ -32,14 +32,14 @@ class AddAcountViewController: UIViewController {
         if(!(name!.isEmpty) || (pass!.isEmpty)){
             let finalPassphrase = pass! as NSString
             let finalPassphraseData = finalPassphrase .data(using: String.Encoding.utf8.rawValue)!
-            if(SingleInstance.shared.wallet?.nextAccount(name, privPass: finalPassphraseData))!{
+            do {
+               try SingleInstance.shared.wallet?.nextAccount(name, privPass: finalPassphraseData)
                 self.dismiss(animated: true, completion: nil)
                 
+            }catch{
+                print("error")
             }
-            else{
-                print("Error")
-                return
-            }
+                
             
         }
         else{

--- a/decred_wallet/view_controller/CreatePasswordViewController.swift
+++ b/decred_wallet/view_controller/CreatePasswordViewController.swift
@@ -29,7 +29,6 @@ class CreatePasswordViewController: UIViewController, SeedCheckupProtocol, UITex
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
-        SingleInstance.shared.wallet?.runGC()
     }
     
     

--- a/decred_wallet/view_controller/OverviewViewController.swift
+++ b/decred_wallet/view_controller/OverviewViewController.swift
@@ -8,8 +8,28 @@ import SlideMenuControllerSwift
 import Mobilewallet
 import MBProgressHUD
 
-class OverviewViewController: UIViewController, MobilewalletGetTransactionsResponseProtocol, MobilewalletTransactionListenerProtocol, MobilewalletBlockNotificationErrorProtocol,
+class OverviewViewController: UIViewController, MobilewalletGetTransactionsResponseProtocol, MobilewalletTransactionListenerProtocol, //MobilewalletBlockNotificationErrorProtocol,
 MobilewalletBlockScanResponseProtocol, MobilewalletSpvSyncResponseProtocol {
+    func onFetchMissingCFilters(_ missingCFitlersStart: Int32, missingCFitlersEnd: Int32, state: String!) {
+        
+    }
+    
+    func onFetchedHeaders(_ fetchedHeadersCount: Int32, lastHeaderTime: Int64, state: String!) {
+       
+    }
+    
+    func onRescan(_ rescannedThrough: Int32, state: String!) {
+        
+    }
+    
+    func onError(_ err: String!) {
+        
+    }
+    
+    func onDiscoveredAddresses(_ state: String!) {
+        
+    }
+    
     func onFetchMissingCFilters(_ missingCFitlersStart: Int32, missingCFitlersEnd: Int32, finished: Bool) {
       
     }
@@ -153,8 +173,9 @@ MobilewalletBlockScanResponseProtocol, MobilewalletSpvSyncResponseProtocol {
             DispatchQueue.global(qos: .background).async { [weak self] in
                 guard let _ = self else { return }
                 do {
+                    SingleInstance.shared.wallet?.add(self)
                     try
-                        SingleInstance.shared.wallet?.spvSync(self, peerAddresses: getPeerAddress(appInstance: appInstance), discoverAccounts: true, privatePassphrase: finalPassphraseData)
+            SingleInstance.shared.wallet?.spvSync(getPeerAddress(appInstance: appInstance))
                     print("done syncing")
                     
                 } catch {
@@ -179,7 +200,7 @@ MobilewalletBlockScanResponseProtocol, MobilewalletSpvSyncResponseProtocol {
     }
     
     func connectToRPCServer(){
-        let appInstance = UserDefaults.standard
+    /*    let appInstance = UserDefaults.standard
         let certificate = try? Data(contentsOf: URL(fileURLWithPath: NSHomeDirectory() + "/Documents/rpc.cert"))
         let username = UserDefaults.standard.string(forKey: "pref_user_name")
         let password = UserDefaults.standard.string(forKey: "pref_user_passwd")
@@ -246,8 +267,8 @@ MobilewalletBlockScanResponseProtocol, MobilewalletSpvSyncResponseProtocol {
                 print(error)
             }
         }
-    }
-
+         */
+}
     
     func updateCurrentBalance(){
         var amount = "0"

--- a/decred_wallet/view_controller/ReceiveViewController.swift
+++ b/decred_wallet/view_controller/ReceiveViewController.swift
@@ -142,7 +142,7 @@ class ReceiveViewController: UIViewController {
     }
     
     private func getAddress(accountNumber : Int32){
-        let receiveAddress = try?SingleInstance.shared.wallet?.address(forAccount: Int32(accountNumber))
+        let receiveAddress = try?SingleInstance.shared.wallet?.currentAddress(Int32(accountNumber))
         print("got address in  ".appending(String(Int64(NSDate().timeIntervalSince1970) - starttime)))
        // UserDefaults.standard.setValue(receiveAddress!, forKey: "KEY_RECENT_ADDRESS")
         DispatchQueue.main.async { [weak self] in

--- a/decred_wallet/view_controller/RecoverWalletViewController.swift
+++ b/decred_wallet/view_controller/RecoverWalletViewController.swift
@@ -58,6 +58,7 @@ class RecoverWalletViewController: UIViewController {
         count = count + 1
         if count == 1{
             self.btnConfirm.isEnabled = false
+            txSeedCheckCombined.text = seedtmp
             let flag = SingleInstance.shared.wallet?.verifySeed(txSeedCheckCombined.text)
             if flag! {
                 performSegue(withIdentifier: "createPassword", sender: nil)

--- a/decred_wallet/view_controller/SendViewController.swift
+++ b/decred_wallet/view_controller/SendViewController.swift
@@ -51,7 +51,6 @@ class SendViewController: UIViewController, UITextFieldDelegate, QRCodeReaderVie
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
-        SingleInstance.shared.wallet?.runGC()
 
     }
     
@@ -98,7 +97,7 @@ class SendViewController: UIViewController, UITextFieldDelegate, QRCodeReaderVie
         var walletaddress = self.walletAddress.text!
         let acountN = (self.selectedAccount?.Number)!
         if !(validateDestinationAddress()){
-            walletaddress = (try!SingleInstance.shared.wallet?.address(forAccount: acountN))!
+            walletaddress = (try!SingleInstance.shared.wallet?.currentAddress(acountN))!
         }
         var fee = 0.0
        
@@ -178,7 +177,6 @@ class SendViewController: UIViewController, UITextFieldDelegate, QRCodeReaderVie
             guard let `self` = self else { return }
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let this = self else { return }
-                SingleInstance.shared.wallet?.runGC()
                 this.signTransaction(sendAll: sendAll)
                // self?.selectedAccount = nil
                 return


### PR DESCRIPTION
Mobile wallet update to the latest version with fix for compile error in Xcode.
Errors including:
- Wallet address error.
- Peer address  error.
- Testnet / mainnet connection error.
- Public key encryption error.
-  Next Account error.
- Mobilewallet call back functions errors
- Update for Pods /Dependencies.


 
   
  
 

   
   


