### PR TITLE
tx details: add options menu

### DIFF
--- a/decred_wallet/DcrdConnection/JsonEntities.swift
+++ b/decred_wallet/DcrdConnection/JsonEntities.swift
@@ -122,7 +122,6 @@ struct GetTransactionResponse: Codable {
 
 struct Transaction: Codable {
     var Hash: String
-    var Transaction: String?
     var Fee: Double
     var Direction: Int
     var Timestamp: UInt64
@@ -132,11 +131,11 @@ struct Transaction: Codable {
     var Height: Int
     var Debits: [Debit]
     var Credits: [Credit]
+    var Raw: String
     @nonobjc var Animate: Bool
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         self.Hash = try values.decodeIfPresent(String.self, forKey: .Hash) ?? ""
-        self.Transaction = try values.decodeIfPresent(String.self, forKey: .Transaction) ?? ""
         self.Fee = try values.decodeIfPresent(Double.self, forKey: .Fee) ?? 0.0
         self.Direction = try values.decodeIfPresent(Int.self, forKey: .Direction) ?? 0
         self.Timestamp = try values.decodeIfPresent(UInt64.self, forKey: .Timestamp) ?? 0
@@ -146,6 +145,7 @@ struct Transaction: Codable {
         self.Height = try values.decodeIfPresent(Int.self, forKey: .Height) ?? 0
         self.Debits = try values.decodeIfPresent([Debit].self, forKey: .Debits) ?? [Debit]()
         self.Credits = try values.decodeIfPresent([Credit].self, forKey: .Credits) ?? [Credit]()
+        self.Raw = try values.decodeIfPresent(String.self, forKey: .Raw) ?? ""
         self.Animate = false
     }
 }

--- a/decred_wallet/view_controller/ReceiveViewController.swift
+++ b/decred_wallet/view_controller/ReceiveViewController.swift
@@ -59,7 +59,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         let shareBtn = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share))
         let generateAddressBtn = UIButton(type: .custom)
         generateAddressBtn.setImage(UIImage(named: "right-menu"), for: .normal)
-        generateAddressBtn.addTarget(self, action: #selector(switchFunc), for: .touchUpInside)
+        generateAddressBtn.addTarget(self, action: #selector(toggleOptionsMenu), for: .touchUpInside)
         generateAddressBtn.frame = CGRect(x: 0, y: 0, width: 10, height: 51)
         let barButton = UIBarButtonItem(customView: generateAddressBtn)
         self.navigationItem.rightBarButtonItems = [barButton, shareBtn ]
@@ -69,7 +69,8 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    @objc func switchFunc(){
+    
+    @objc func toggleOptionsMenu(){
         self.menuOptionView.isHidden = !self.menuOptionView.isHidden
         
     }
@@ -77,7 +78,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     @IBAction private func generateNewAddress() {
         self.oldAddress = self.walletAddress.currentTitle!
         self.getNextAddress(accountNumber: (self.myacc.Number))
-        self.switchFunc()
+        self.toggleOptionsMenu()
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/decred_wallet/view_controller/TransactionFullDetails/Cells/TransactiontInputDetails.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/Cells/TransactiontInputDetails.swift
@@ -14,8 +14,11 @@ class TransactiontInputDetails: UITableViewCell {
     
     var expandOrCollapse: (() -> Void)?
     
-    func setup(with debits:[Debit], decodedInputs: [DecodedInput]){
+    var presentingController: TransactionFullDetailsViewController!
+    
+    func setup(with debits:[Debit], decodedInputs: [DecodedInput], presentingController: TransactionFullDetailsViewController){
         alcDebitStackHeight.constant = 0
+        self.presentingController = presentingController
         
         var walletInputIndices = [Int]()
         
@@ -95,8 +98,9 @@ class TransactiontInputDetails: UITableViewCell {
             //Copy a string to the pasteboard.
             UIPasteboard.general.string = sender.titleLabel?.text
             //Alert
-            let alertController = UIAlertController(title: "", message: "address copied", preferredStyle: UIAlertControllerStyle.alert)
+            let alertController = UIAlertController(title: "", message: "Previous outpoint copied!", preferredStyle: UIAlertControllerStyle.alert)
             alertController.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler: nil))
+            self.presentingController.present(alertController, animated: true, completion: nil)
         }
     }
 }

--- a/decred_wallet/view_controller/TransactionFullDetails/Cells/TransactiontOutputDetailsCell.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/Cells/TransactiontOutputDetailsCell.swift
@@ -16,9 +16,11 @@ class TransactiontOutputDetailsCell: UITableViewCell {
     
     var expandOrCollapse: (() -> Void)?
     
-    func setup(with credits:[Credit], decodedOutputs: [DecodedOutput]){
-        
+    var presentingController: TransactionFullDetailsViewController!
+    
+    func setup(with credits:[Credit], decodedOutputs: [DecodedOutput], presentingController: TransactionFullDetailsViewController){
         alcCreditStackHeight.constant = 0
+        self.presentingController = presentingController
         
         var walletOutputIndices = [Int]()
         
@@ -98,8 +100,9 @@ class TransactiontOutputDetailsCell: UITableViewCell {
             //Copy a string to the pasteboard.
             UIPasteboard.general.string = sender.titleLabel?.text
             //Alert
-            let alertController = UIAlertController(title: "", message: "address copied", preferredStyle: UIAlertControllerStyle.alert)
+            let alertController = UIAlertController(title: "", message: "Address copied!", preferredStyle: UIAlertControllerStyle.alert)
             alertController.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler: nil))
+            self.presentingController.present(alertController, animated: true, completion: nil)
         }
     }
 }

--- a/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.storyboard
+++ b/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.storyboard
@@ -27,19 +27,78 @@
                                     <outlet property="delegate" destination="Gia-AO-cm1" id="RFq-hW-lfF"/>
                                 </connections>
                             </tableView>
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Pw-I1-PFM">
+                                <rect key="frame" x="147" y="21" width="220" height="142.5"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="9YJ-4h-4u9">
+                                        <rect key="frame" x="8" y="14.5" width="154" height="114"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iSM-dp-Rau">
+                                                <rect key="frame" x="0.0" y="0.0" width="154" height="30"/>
+                                                <state key="normal" title="Copy transaction hash">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="copyTransactionHash:" destination="Gia-AO-cm1" eventType="touchUpInside" id="xT0-DA-NGy"/>
+                                                </connections>
+                                            </button>
+                                            <view autoresizesSubviews="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hjd-Vl-a6S" userLabel="divider">
+                                                <rect key="frame" x="0.0" y="41" width="240" height="50"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </view>
+                                            <button opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kHf-1F-YNi">
+                                                <rect key="frame" x="0.0" y="41" width="154" height="32"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                <state key="normal" title="Copy raw transaction">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="copyRawTransaction:" destination="Gia-AO-cm1" eventType="touchUpInside" id="ahf-v4-NDt"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d6h-g7-KCg">
+                                                <rect key="frame" x="0.0" y="84" width="154" height="30"/>
+                                                <state key="normal" title="View on Dcrdata">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="viewOnDcrdata:" destination="Gia-AO-cm1" eventType="touchUpInside" id="Ykz-W8-L5E"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <variation key="default">
+                                            <mask key="subviews">
+                                                <exclude reference="hjd-Vl-a6S"/>
+                                            </mask>
+                                        </variation>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.14014340750000001" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="9YJ-4h-4u9" firstAttribute="width" secondItem="1Pw-I1-PFM" secondAttribute="width" multiplier="0.7" id="3PC-NG-dbk"/>
+                                    <constraint firstItem="9YJ-4h-4u9" firstAttribute="leading" secondItem="1Pw-I1-PFM" secondAttribute="leading" constant="8" id="bHd-fR-PMe"/>
+                                    <constraint firstItem="9YJ-4h-4u9" firstAttribute="height" secondItem="1Pw-I1-PFM" secondAttribute="height" multiplier="0.8" id="bKA-j8-ku2"/>
+                                    <constraint firstItem="9YJ-4h-4u9" firstAttribute="centerY" secondItem="1Pw-I1-PFM" secondAttribute="centerY" id="dIo-uA-RKm"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="dx6-nC-hdi" firstAttribute="leading" secondItem="Jia-se-qbj" secondAttribute="leading" id="CSr-m8-nbn"/>
+                            <constraint firstItem="Jia-se-qbj" firstAttribute="trailing" secondItem="1Pw-I1-PFM" secondAttribute="trailing" constant="8" id="KZX-au-deZ"/>
                             <constraint firstItem="Jia-se-qbj" firstAttribute="bottom" secondItem="dx6-nC-hdi" secondAttribute="bottom" id="Y4W-wK-Ien"/>
                             <constraint firstItem="dx6-nC-hdi" firstAttribute="top" secondItem="Jia-se-qbj" secondAttribute="top" id="h0o-BZ-gG0"/>
                             <constraint firstItem="Jia-se-qbj" firstAttribute="trailing" secondItem="dx6-nC-hdi" secondAttribute="trailing" id="nm0-X6-iQL"/>
+                            <constraint firstItem="1Pw-I1-PFM" firstAttribute="top" secondItem="Jia-se-qbj" secondAttribute="top" constant="1" id="oth-Eq-SH1"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Jia-se-qbj"/>
                     </view>
                     <connections>
                         <outlet property="amount" destination="I0P-ya-PoI" id="XOh-SQ-Xpg"/>
                         <outlet property="detailsHeader" destination="9Ha-a1-zJH" id="Yu4-gV-Li4"/>
+                        <outlet property="optionsMenu" destination="1Pw-I1-PFM" id="qua-dA-1QH"/>
                         <outlet property="tableTransactionDetails" destination="dx6-nC-hdi" id="Lf9-c4-Per"/>
                         <outlet property="tableView" destination="dx6-nC-hdi" id="gOC-Y9-JtM"/>
                     </connections>
@@ -78,7 +137,7 @@
                     <viewLayoutGuide key="safeArea" id="pew-yZ-hLF"/>
                 </view>
             </objects>
-            <point key="canvasLocation" x="-42" y="-204"/>
+            <point key="canvasLocation" x="-42.399999999999999" y="-204.64767616191907"/>
         </scene>
     </scenes>
 </document>

--- a/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
@@ -133,7 +133,7 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         case 1:
             
             let cell = tableView.dequeueReusableCell(withIdentifier: "TransactiontInputDetails") as! TransactiontInputDetails
-            cell.setup(with: transaction.Debits, decodedInputs: decodedTransaction.Inputs)
+            cell.setup(with: transaction.Debits, decodedInputs: decodedTransaction.Inputs, presentingController: self)
             cell.expandOrCollapse = { [weak self] in
                 self?.tableTransactionDetails.reloadData()
             }
@@ -142,7 +142,7 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         case 2:
             
             let cell = tableView.dequeueReusableCell(withIdentifier: "TransactiontOutputDetailsCell") as! TransactiontOutputDetailsCell
-            cell.setup(with: transaction.Credits, decodedOutputs: decodedTransaction.Outputs)
+            cell.setup(with: transaction.Credits, decodedOutputs: decodedTransaction.Outputs, presentingController: self)
             cell.expandOrCollapse = { [weak self] in
                 self?.tableTransactionDetails.reloadData()
             }

--- a/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
@@ -14,6 +14,8 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet var detailsHeader: UIView!
     @IBOutlet weak var amount: UILabel!
+    @IBOutlet weak var optionsMenu: UIView!
+    
     
     var transactionHash: String?
     var account : String?
@@ -40,6 +42,12 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         self.slideMenuController()?.removeLeftGestures()
         self.navigationItem.title = "Transaction Details"
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "left-arrow"), style: .done, target: self, action: #selector(backk))
+        
+        self.optionsMenu.layer.cornerRadius = 3
+        self.optionsMenu.layer.shadowColor = UIColor.black.cgColor
+        self.optionsMenu.layer.shadowOffset = CGSize(width: 0, height: 1.0)
+        self.optionsMenu.layer.shadowOpacity = 0.2
+        self.optionsMenu.layer.shadowRadius = 4.0
     }
     
     @objc func backk(){
@@ -50,6 +58,13 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         
         self.navigationItem.title = "Transaction Details"
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "left-arrow"), style: .done, target: self, action: #selector(backk))
+       
+        let optionsMenuButton = UIButton(type: .custom)
+        optionsMenuButton.setImage(UIImage(named: "right-menu"), for: .normal)
+        optionsMenuButton.addTarget(self, action: #selector(toggleOptionsMenu), for: .touchUpInside)
+        optionsMenuButton.frame = CGRect(x: 0, y: 0, width: 10, height: 51)
+        let barButton = UIBarButtonItem(customView: optionsMenuButton)
+        self.navigationItem.rightBarButtonItems = [barButton]
         
         do {
             if let data = Data(fromHexEncodedString: self.transaction.Hash) {
@@ -63,6 +78,26 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         }
         
         wrap(transaction: self.transaction)
+    }
+    
+    @objc func toggleOptionsMenu(){
+        print("Bar button clicked \(self.optionsMenu.isHidden)")
+        self.optionsMenu.isHidden = !self.optionsMenu.isHidden
+    }
+    
+    @IBAction func copyRawTransaction(_ sender: Any) {
+        copyText(text: transaction.Raw)
+        toggleOptionsMenu()
+    }
+    
+    @IBAction func copyTransactionHash(_ sender: Any) {
+        copyText(text: transaction.Hash)
+        toggleOptionsMenu()
+    }
+    
+    @IBAction func viewOnDcrdata(_ sender: Any) {
+        openLink(urlString: "https://testnet.dcrdata.org/tx/\(transaction.Hash)")
+        toggleOptionsMenu()
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -123,30 +158,21 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         case 0:
             
             if indexPath.row == 6 {
-                self.openLink(urlString: "https://testnet.dcrdata.org/tx/" + transaction.Hash)
+                copyText(text: transaction.Hash)
             }
-            
-        case 1:
-            
-            let cell = tableView.dequeueReusableCell(withIdentifier: "TransactiontInputDetails") as! TransactiontInputDetails
-            copyHash(hash: "")
-            
-        case 2:
-            
-            let cell = tableView.dequeueReusableCell(withIdentifier: "TransactiontOutputDetailsCell") as! TransactiontOutputDetailsCell
             
         default:
             return
         }
     }
     
-    private func copyHash(hash: String){
+    private func copyText(text: String){
         DispatchQueue.main.async {
             //Copy a string to the pasteboard.
-            UIPasteboard.general.string = hash
+            UIPasteboard.general.string = text
             
             //Alert
-            let alertController = UIAlertController(title: "", message: "Hash copied", preferredStyle: UIAlertControllerStyle.alert)
+            let alertController = UIAlertController(title: "", message: "Copied", preferredStyle: UIAlertControllerStyle.alert)
             alertController.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler: nil))
             self.present(alertController, animated: true, completion: nil)
         }


### PR DESCRIPTION
Closes #143 & #226
- Add buttons to copy raw tx, copy tx hash and view tx on dcrdata
- Set tapping on tx hash to copy instead of opening dcrdata
- show success dialog after copying an item to clipboard(#226)

![simulator screen shot - iphone xr - 2019-03-01 at 08 06 39](https://user-images.githubusercontent.com/19960200/53622082-f5022f00-3bf8-11e9-8c42-aae6d8e13d99.png)

![ezgif com-optimize](https://user-images.githubusercontent.com/19960200/53676947-5b468a80-3ca9-11e9-8ae1-75723594155c.gif)