### PR TITLE
fix build issues using dcrlibwallet generated with latest gomobile version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ IOS 10.3 or above.
 [Xcode](https://developer.apple.com/xcode/) and [Dcrlibwallet](https://github.com/raedahgroup/dcrlibwallet) are required to build this project.
 
 Clone this repo and run `build_wallet_framework.sh` to build Dcrlibwallet and add the generated library as a framework to the Xcode project (requires [go to be installed](http://golang.org/doc/install) with $GOPATH set and [Gomobile](https://github.com/golang/go/wiki/Mobile#tools) installed and initialized with `gomobile init`). Then open this project with Xcode and build.
+
+It's important to have your generated `Dcrlibwallet.framework` binary in `./libs` directory for the project to build with Xcode. This should be automatically done if you run `build_wallet_framework.sh`.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Clone this repo, install and setup the following software tools. The versions in
 
 ### Requirements
 - [Xcode](https://developer.apple.com/xcode/). _(Version 10.1)_.
-- [Go](http://golang.org/doc/install). _(Version 1.12.1 tested, 1.11 should work too)_. Ensure your `$GOPATH` environment variable is set and that `$GOPATH/bin` is added to your `$PATH` environment variable.
-- [Gomobile](https://github.com/golang/go/wiki/Mobile#tools). `go get golang.org/x/mobile/cmd/gomobile` and `gomobile init` should suffice. If you experience issues with any of those commands, look [here](https://github.com/golang/go/issues).
+- [Go](http://golang.org/doc/install). _(Version 1.12.1 tested, 1.11 should work too)_.
+Ensure your `$GOPATH` environment variable is set and that `$GOPATH/bin` is added to your `$PATH` environment variable.
+- [Gomobile](https://github.com/golang/go/wiki/Mobile#tools) _(latest version)_.
+Run `go get golang.org/x/mobile/cmd/gomobile`  to ensure you're using the latest version of `gomobile`. Run `gomobile init` afterwards to setup `gomobile`.
 
 ### Building/running the app
 - Run `pod install` to download project dependencies.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Clone this repo, install and setup the following software tools. The versions in
 ### Requirements
 - [Xcode](https://developer.apple.com/xcode/). _(Version 10.1)_.
 - [Go](http://golang.org/doc/install). _(Version 1.12.1 tested, 1.11 should work too)_.
-Ensure your `$GOPATH` environment variable is set and that `$GOPATH/bin` is added to your `$PATH` environment variable.
+  - Ensure your `$GOPATH` environment variable is set and that `$GOPATH/bin` is added to your `$PATH` environment variable.
 - [Gomobile](https://github.com/golang/go/wiki/Mobile#tools) _(latest version)_.
-Run `go get golang.org/x/mobile/cmd/gomobile`  to ensure you're using the latest version of `gomobile`. Run `gomobile init` afterwards to setup `gomobile`.
+  - Run `go get golang.org/x/mobile/cmd/gomobile`  to ensure you're using the latest version of `gomobile`.
+  - Run `gomobile init` afterwards to setup `gomobile`.
 
 ### Building/running the app
 - Run `pod install` to download project dependencies.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,14 @@ A Decred Mobile Wallet for iOS that runs on top of [dcrwallet](https://github.co
 IOS 10.3 or above.
 
 ## Build Instructions
-[Xcode](https://developer.apple.com/xcode/) and [Dcrlibwallet](https://github.com/raedahgroup/dcrlibwallet) are required to build this project.
+Clone this repo, install and setup the following software tools. The versions in brackets are not definite, other versions may work. This process has been confirmed working with the versions specified.
 
-Clone this repo and run `build_wallet_framework.sh` to build Dcrlibwallet and add the generated library as a framework to the Xcode project (requires [go to be installed](http://golang.org/doc/install) with $GOPATH set and [Gomobile](https://github.com/golang/go/wiki/Mobile#tools) installed and initialized with `gomobile init`). Then open this project with Xcode and build.
+### Requirements
+- [Xcode](https://developer.apple.com/xcode/). _(Version 10.1)_.
+- [Go](http://golang.org/doc/install). _(Version 1.12.1 tested, 1.11 should work too)_. Ensure your `$GOPATH` environment variable is set and that `$GOPATH/bin` is added to your `$PATH` environment variable.
+- [Gomobile](https://github.com/golang/go/wiki/Mobile#tools). `go get golang.org/x/mobile/cmd/gomobile` and `gomobile init` should suffice. If you experience issues with any of those commands, look [here](https://github.com/golang/go/issues).
 
-It's important to have your generated `Dcrlibwallet.framework` binary in `./libs` directory for the project to build with Xcode. This should be automatically done if you run `build_wallet_framework.sh`.
+### Building/running the app
+- Run `pod install` to download project dependencies.
+- Run `build_wallet_framework.sh` to generate `dcrlibwallet.framework` using a preset revision/commit of [dcrlibwallet](https://github.com/raedahgroup/dcrlibwallet). The generated `Dcrlibwallet.framework` binary will be placed in `./libs` sub-directory.
+- Open `decred_wallet.xcworkspace` with Xcode and build/run.

--- a/build_wallet_framework.sh
+++ b/build_wallet_framework.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-export DEBUG_LIB_DIR=$(pwd)/debug
-export RELEASE_LIB_DIR=$(pwd)/release
+export LIB_DIR=$(pwd)/libs
 export DCRLIBWALLET_GIT_DIR=$GOPATH/src/github.com/raedahgroup/dcrlibwallet
 
 main() {
@@ -24,12 +23,16 @@ cloneDcrlibwallet() {
 	rm -rf $DCRLIBWALLET_GIT_DIR
 	mkdir -p $DCRLIBWALLET_GIT_DIR
 	git clone https://github.com/raedahgroup/dcrlibwallet.git $DCRLIBWALLET_GIT_DIR
+	# update with the appropriate tag/commit hash to checkout 
+	git checkout v1.0.0
 	echo "done cloning dcrlibwallet"
 }
 
 updateDcrlibwallet() {
 	cd $DCRLIBWALLET_GIT_DIR
-	git checkout master && git pull origin master
+	git fetch
+	# update with the appropriate tag/commit hash to checkout 
+	git checkout v1.0.0
 	echo "done updating dcrlibwallet"
 }
 
@@ -45,12 +48,9 @@ buildDcrlibwallet() {
 }
 
 copyLibrary() {
-	rm -rf $DEBUG_LIB_DIR
-	rm -rf $RELEASE_LIB_DIR
-	mkdir $DEBUG_LIB_DIR
-	mkdir $RELEASE_LIB_DIR
-	cp -R -f Dcrlibwallet.framework $DEBUG_LIB_DIR/Dcrlibwallet.framework
-	cp -R -f Dcrlibwallet.framework $RELEASE_LIB_DIR/Dcrlibwallet.framework
+	rm -rf $LIB_DIR
+	mkdir $LIB_DIR
+	cp -R -f Dcrlibwallet.framework $LIB_DIR/Dcrlibwallet.framework
 	echo "done"
 }
 

--- a/decred_wallet.xcodeproj/project.pbxproj
+++ b/decred_wallet.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		95CC024420D3F15800DA73AF /* AccountsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CC024320D3F15800DA73AF /* AccountsData.swift */; };
 		95E1C96E20FCD43E00D7F3EE /* TextFieldDoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E1C96D20FCD43E00D7F3EE /* TextFieldDoneButton.swift */; };
 		B38F4545227062A60068F33D /* Pods_Decred_Wallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B38F4544227062A60068F33D /* Pods_Decred_Wallet.framework */; };
-		B38F4548227066CA0068F33D /* Dcrlibwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B38F4546227062B50068F33D /* Dcrlibwallet.framework */; };
+		B39F41C82278DB8300F6F202 /* Dcrlibwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B39F41C72278DB8300F6F202 /* Dcrlibwallet.framework */; };
 		DD0B356E218930B7000830C4 /* AddAcountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0B356D218930B7000830C4 /* AddAcountViewController.swift */; };
 		DD0C493E208A160900986C6B /* WalletSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0C493D208A160900986C6B /* WalletSetupViewController.swift */; };
 		DD1D5C7C20AED828009789DD /* certificateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1D5C7B20AED824009789DD /* certificateViewController.swift */; };
@@ -139,8 +139,8 @@
 
 /* Begin PBXFileReference section */
 		109877DFD2DABA7636DA7B92 /* Pods-Decred WalletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred WalletTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Decred WalletTests/Pods-Decred WalletTests.debug.xcconfig"; sourceTree = "<group>"; };
-		22EDE8529570C09D6690267C /* Pods-Decred Wallet.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet.xcconfig"; path = "Pods/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet.xcconfig"; sourceTree = "<group>"; };
 		17F5813DCC6A088BFD853176 /* Pods-Decred Wallet.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet.xcconfig"; path = "Pods/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet.xcconfig"; sourceTree = "<group>"; };
+		22EDE8529570C09D6690267C /* Pods-Decred Wallet.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet.xcconfig"; path = "Pods/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet.xcconfig"; sourceTree = "<group>"; };
 		2804D43221BAAD170011A5B3 /* SeedCheckActiveCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCheckActiveCellView.swift; sourceTree = "<group>"; };
 		28102DCC21B83E700052DC00 /* ContouredButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContouredButton.swift; sourceTree = "<group>"; };
 		28102DCE21B83F8F0052DC00 /* SeedConfirmTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedConfirmTableViewCell.swift; sourceTree = "<group>"; };
@@ -217,11 +217,12 @@
 		95CC024320D3F15800DA73AF /* AccountsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsData.swift; sourceTree = "<group>"; };
 		95E1C96D20FCD43E00D7F3EE /* TextFieldDoneButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldDoneButton.swift; sourceTree = "<group>"; };
 		A1A97C56BC75512DA55A8A70 /* Pods-Decred WalletTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred WalletTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Decred WalletTests/Pods-Decred WalletTests.release.xcconfig"; sourceTree = "<group>"; };
+		A74FC566DAEDABB3270B71AC /* libPods-Decred WalletTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Decred WalletTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B38F4544227062A60068F33D /* Pods_Decred_Wallet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_Decred_Wallet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B38F4546227062B50068F33D /* Dcrlibwallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dcrlibwallet.framework; path = debug/Dcrlibwallet.framework; sourceTree = "<group>"; };
+		B39F41C72278DB8300F6F202 /* Dcrlibwallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dcrlibwallet.framework; path = libs/Dcrlibwallet.framework; sourceTree = "<group>"; };
 		B3A32AA9227012BB00CDD53D /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = Pods/Crashlytics/Crashlytics.framework; sourceTree = "<group>"; };
 		BDFD22D327AF7F80DA90882F /* libPods-Decred WalletTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Decred WalletTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A74FC566DAEDABB3270B71AC /* libPods-Decred WalletTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Decred WalletTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7A8C8EBEB9AB2C55421E1B9 /* Pods-Decred WalletTests.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred WalletTests.testnet.xcconfig"; path = "Pods/Target Support Files/Pods-Decred WalletTests/Pods-Decred WalletTests.testnet.xcconfig"; sourceTree = "<group>"; };
 		DD0B356D218930B7000830C4 /* AddAcountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddAcountViewController.swift; path = view_controller/AddAcountViewController.swift; sourceTree = "<group>"; };
 		DD0C493D208A160900986C6B /* WalletSetupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSetupViewController.swift; sourceTree = "<group>"; };
@@ -275,7 +276,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B38F4548227066CA0068F33D /* Dcrlibwallet.framework in Frameworks */,
+				B39F41C82278DB8300F6F202 /* Dcrlibwallet.framework in Frameworks */,
 				B38F4545227062A60068F33D /* Pods_Decred_Wallet.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -368,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				B38F4546227062B50068F33D /* Dcrlibwallet.framework */,
+				B39F41C72278DB8300F6F202 /* Dcrlibwallet.framework */,
 				B38F4544227062A60068F33D /* Pods_Decred_Wallet.framework */,
 				B3A32AA9227012BB00CDD53D /* Crashlytics.framework */,
 				28FD1BD0208F6C9A0051F58F /* Pods_Decred_Wallet.framework */,
@@ -1001,7 +1003,7 @@
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/debug",
+					"$(PROJECT_DIR)/libs",
 				);
 				INFOPLIST_FILE = decred_wallet/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
@@ -1102,7 +1104,7 @@
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/debug",
+					"$(PROJECT_DIR)/libs",
 				);
 				INFOPLIST_FILE = decred_wallet/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
@@ -1260,7 +1262,7 @@
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/debug",
+					"$(PROJECT_DIR)/libs",
 				);
 				INFOPLIST_FILE = decred_wallet/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
@@ -1290,7 +1292,7 @@
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/debug",
+					"$(PROJECT_DIR)/libs",
 				);
 				INFOPLIST_FILE = decred_wallet/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;

--- a/decred_wallet/view_controller/AccountViewController.swift
+++ b/decred_wallet/view_controller/AccountViewController.swift
@@ -75,7 +75,12 @@ class AccountViewController: UIViewController, UITableViewDataSource, UITableVie
             this.account?.Acc.removeAll()
             this.myBalances.removeAll()
             do {
-                let strAccount = try SingleInstance.shared.wallet?.getAccounts(0)
+                var getAccountError: NSError?
+                let strAccount = SingleInstance.shared.wallet?.getAccounts(0, error: &getAccountError)
+                if getAccountError != nil {
+                    throw getAccountError!
+                }
+                
                 this.account = try JSONDecoder().decode(GetAccountResponse.self, from: (strAccount?.data(using: .utf8))!)
                 this.myBalances = {
                     var colorCount = -1

--- a/decred_wallet/view_controller/GeneratedSeedDisplayViewController.swift
+++ b/decred_wallet/view_controller/GeneratedSeedDisplayViewController.swift
@@ -29,12 +29,12 @@ class GeneratedSeedDisplayViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        do{
-            try
-                self.seed =  (SingleInstance.shared.wallet?.generateSeed())
-        } catch {
-            seed = ""
+        var generateSeedError: NSError?
+        self.seed =  (SingleInstance.shared.wallet?.generateSeed(&generateSeedError))
+        if generateSeedError != nil {
+            print("seed generate error: \(generateSeedError?.localizedDescription)")
         }
+        
         arrWords = (seed.components(separatedBy: " "))
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) { [weak self] in

--- a/decred_wallet/view_controller/ReceiveViewController.swift
+++ b/decred_wallet/view_controller/ReceiveViewController.swift
@@ -97,7 +97,12 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         
         self.account?.Acc.removeAll()
         do{
-            let strAccount = try self.wallet?.getAccounts(0)
+            var getAccountError: NSError?
+            let strAccount = try self.wallet?.getAccounts(0, error: &getAccountError)
+            if getAccountError != nil {
+                throw getAccountError!
+            }
+            
             self.account = try JSONDecoder().decode(GetAccountResponse.self, from: (strAccount?.data(using: .utf8))!)
         } catch let error{
             print(error)
@@ -138,7 +143,11 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         
         self.account?.Acc.removeAll()
         do{
-            let strAccount = try self.wallet?.getAccounts(0)
+            var getAccountError: NSError?
+            let strAccount = self.wallet?.getAccounts(0, error: &getAccountError)
+            if getAccountError != nil {
+                throw getAccountError!
+            }
             self.account = try JSONDecoder().decode(GetAccountResponse.self, from: (strAccount?.data(using: .utf8))!)
         } catch let error{
             print(error)
@@ -194,29 +203,27 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         }
     }
     
-    private func getAddress(accountNumber : Int32){
-        
-        let receiveAddress = try?self.wallet?.currentAddress(Int32(accountNumber))
+    private func getAddress(accountNumber : Int32) {
+        let receiveAddress = self.wallet?.currentAddress(Int32(accountNumber), error: nil)
         DispatchQueue.main.async { [weak self] in
             guard let this = self else { return }
             
             this.lblWalletAddress.text = receiveAddress!
             this.imgWalletAddrQRCode.image = generateQRCodeFor(
-                with: receiveAddress!!,
+                with: receiveAddress!,
                 forImageViewFrame: this.imgWalletAddrQRCode.frame
             )
         }
     }
     
     @objc private func getNextAddress(accountNumber : Int32){
-        
-        let receiveAddress = try?self.wallet?.nextAddress(Int32(accountNumber))
+        let receiveAddress = self.wallet?.nextAddress(Int32(accountNumber), error: nil)
         DispatchQueue.main.async { [weak self] in
             guard let this = self else { return }
             if (this.oldAddress != receiveAddress!) {
                 this.lblWalletAddress.text = receiveAddress!
                 this.imgWalletAddrQRCode.image = generateQRCodeFor(
-                    with: receiveAddress!!,
+                    with: receiveAddress!,
                     forImageViewFrame: this.imgWalletAddrQRCode.frame
                 )
                 return

--- a/decred_wallet/view_controller/SendViewController.swift
+++ b/decred_wallet/view_controller/SendViewController.swift
@@ -294,7 +294,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         var fee = 0.0
         
         if !(validateDestinationAddress()) {
-            walletaddress = (try!wallet?.currentAddress(acountN))!
+            walletaddress = (wallet?.currentAddress(acountN, error: nil))!
         }
         
         DispatchQueue.global(qos: .userInitiated).async {
@@ -322,7 +322,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
                         this.tfAmount.text = "\(DcrlibwalletAmountCoin(amount - DcrlibwalletAmountAtom(fee)) )"
                     }
                 }
-            } catch let error {
+            } catch {
                // self.showAlert(message: error.localizedDescription, titles: "Error")
             }
         }
@@ -338,9 +338,9 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
             return
         }
           var walletAddress = ""
-        if (self.toAddressContainer.isHidden){
-            let receiveAddress = try?wallet?.currentAddress((self.sendToAccount?.Number)!)
-            walletAddress = (receiveAddress!)!
+        if (self.toAddressContainer.isHidden) {
+            let receiveAddress = wallet?.currentAddress((self.sendToAccount?.Number)!, error: nil)
+            walletAddress = receiveAddress!
         }
         else{
             DispatchQueue.main.async {
@@ -389,8 +389,8 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         confirmSendFundViewController.view.addGestureRecognizer(tap)
         DispatchQueue.main.async {
             if (self.toAddressContainer.isHidden){
-                let receiveAddress = try?self.wallet?.currentAddress((self.sendToAccount?.Number)!)
-                confirmSendFundViewController.address = (receiveAddress!)!
+                let receiveAddress = self.wallet?.currentAddress((self.sendToAccount?.Number)!, error: nil)
+                confirmSendFundViewController.address = receiveAddress!
                 confirmSendFundViewController.account = (self.selectedAccount?.Name)!
             }
             else{
@@ -434,8 +434,8 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         confirmSendFundViewController.view.addGestureRecognizer(tap)
          DispatchQueue.main.async {
             if (self.toAddressContainer.isHidden){
-                let receiveAddress = try?self.wallet?.currentAddress((self.sendToAccount?.Number)!)
-                confirmSendFundViewController.address = (receiveAddress!)!
+                let receiveAddress = self.wallet?.currentAddress((self.sendToAccount?.Number)!, error: nil)
+                confirmSendFundViewController.address = receiveAddress!
                 confirmSendFundViewController.account = (self.selectedAccount?.Name)!
             }
             else{
@@ -907,7 +907,11 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         var accounts = [String]()
         var account: GetAccountResponse?
         do {
-            let strAccount = try wallet?.getAccounts(0)
+            var getAccountError: NSError?
+            let strAccount = try wallet?.getAccounts(0, error: &getAccountError)
+            if getAccountError != nil {
+                throw getAccountError!
+            }
             account = try JSONDecoder().decode(GetAccountResponse.self, from: (strAccount?.data(using: .utf8))!)
             
         } catch let error {
@@ -947,7 +951,11 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         var accounts = [String]()
         var account: GetAccountResponse?
         do {
-            let strAccount = try wallet?.getAccounts(0)
+            var getAccountError: NSError?
+            let strAccount = wallet?.getAccounts(0, error: &getAccountError)
+            if getAccountError != nil {
+                throw getAccountError!
+            }
             account = try JSONDecoder().decode(GetAccountResponse.self, from: (strAccount?.data(using: .utf8))!)
             
         } catch let error {

--- a/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
@@ -62,9 +62,14 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         
         do {
             if let data = Data(fromHexEncodedString: self.transaction.Hash) {
-                let decodedTxJson = try SingleInstance.shared.wallet?.decodeTransaction(data)
+                var decodeTxError: NSError?
+                let decodedTxJson = SingleInstance.shared.wallet?.decodeTransaction(data, error: &decodeTxError)
+                if decodeTxError != nil {
+                    throw decodeTxError!
+                }
+                
                 self.decodedTransaction = try JSONDecoder().decode(DecodedTransaction.self, from: (decodedTxJson?.data(using: .utf8))!)
-            }else{
+            } else {
                 print("invalid hex string")
             }
         } catch let error {


### PR DESCRIPTION
`build_wallet_framework.sh` is updated to generate `dcrlibwallet.framework` using `gomobile` and the v1.0.0 tag of `dcrlibwallet`.

This PR fixes xcode build issues that surface when using a `dcrlibwallet.framework` binary generated with the latest version of `gomobile`. This implies that this PR (and after this PR is merged, master too) will only work with `dcrlibwallet.framework` generated using the latest version of `gomobile`. 