### PR TITLE
Fix truncated date text on overview and history pages (iPod Touch/iPhone 5s)

### DIFF
--- a/decred_wallet/table_view_cell/DataTableViewCell.xib
+++ b/decred_wallet/table_view_cell/DataTableViewCell.xib
@@ -35,7 +35,7 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kgG-PH-sxi">
                         <rect key="frame" x="198" y="11" width="111" height="38"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yJZ-Jw-X76">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="yJZ-Jw-X76">
                                 <rect key="frame" x="0.0" y="21" width="84" height="14"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="Yi3-hX-x8c"/>


### PR DESCRIPTION
closes #348 

<img width="300" src="https://user-images.githubusercontent.com/794430/57050394-461fb500-6c74-11e9-811d-0da8218a3ad2.png">
<img width="300" src="https://user-images.githubusercontent.com/794430/57050397-4750e200-6c74-11e9-89a8-33a9b121313d.png">