### PR TITLE
Fix crash on PIN display for send and add account

### DIFF
--- a/decred_wallet/SecurityMenuViewController.swift
+++ b/decred_wallet/SecurityMenuViewController.swift
@@ -299,7 +299,7 @@ class SecurityMenuViewController: UIViewController,UITextFieldDelegate {
             
             self.present(alert, animated: true, completion: nil)
         }else{
-            let requestPinVC = storyboard!.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController
+            let requestPinVC = RequestPinViewController.instantiate()
             requestPinVC.securityFor = "Spending"
             requestPinVC.showCancelButton = true
             requestPinVC.onUserEnteredPin = { pin in

--- a/decred_wallet/view_controller/AddAcountViewController.swift
+++ b/decred_wallet/view_controller/AddAcountViewController.swift
@@ -37,7 +37,8 @@ class AddAcountViewController: UIViewController {
             if SpendingPinOrPassword.currentSecurityType() == SecurityViewController.SECURITY_TYPE_PASSWORD {
                 addAccountWithoutPin()
             }else{
-                let requestPinVC = storyboard!.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController
+                let storyboard2 =  UIStoryboard(name: "Security", bundle: nil)
+                let requestPinVC = storyboard2.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController
                 requestPinVC.securityFor = "Spending"
                 requestPinVC.showCancelButton = true
                 requestPinVC.onUserEnteredPin = { pin in

--- a/decred_wallet/view_controller/AddAcountViewController.swift
+++ b/decred_wallet/view_controller/AddAcountViewController.swift
@@ -37,8 +37,7 @@ class AddAcountViewController: UIViewController {
             if SpendingPinOrPassword.currentSecurityType() == SecurityViewController.SECURITY_TYPE_PASSWORD {
                 addAccountWithoutPin()
             }else{
-                let storyboard2 =  UIStoryboard(name: "Security", bundle: nil)
-                let requestPinVC = storyboard2.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController
+                let requestPinVC = RequestPinViewController.instantiate()
                 requestPinVC.securityFor = "Spending"
                 requestPinVC.showCancelButton = true
                 requestPinVC.onUserEnteredPin = { pin in

--- a/decred_wallet/view_controller/SendViewController.swift
+++ b/decred_wallet/view_controller/SendViewController.swift
@@ -270,8 +270,8 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
             if SpendingPinOrPassword.currentSecurityType() == SecurityViewController.SECURITY_TYPE_PASSWORD {
                 self.confirmSend(sendAll: false)
             } else {
-                let storyboard2 =  UIStoryboard(name: "Security", bundle: nil)
-                let requestPinVC = storyboard2.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController                requestPinVC.securityFor = "Spending"
+                let requestPinVC = RequestPinViewController.instantiate()
+                requestPinVC.securityFor = "Spending"
                 requestPinVC.showCancelButton = true
                 requestPinVC.onUserEnteredPin = { pin in
                     self.confirmSendWithoutPin(sendAll: false, pin: pin)

--- a/decred_wallet/view_controller/SendViewController.swift
+++ b/decred_wallet/view_controller/SendViewController.swift
@@ -270,8 +270,8 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
             if SpendingPinOrPassword.currentSecurityType() == SecurityViewController.SECURITY_TYPE_PASSWORD {
                 self.confirmSend(sendAll: false)
             } else {
-                let requestPinVC = storyboard!.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController
-                requestPinVC.securityFor = "Spending"
+                let storyboard2 =  UIStoryboard(name: "Security", bundle: nil)
+                let requestPinVC = storyboard2.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController                requestPinVC.securityFor = "Spending"
                 requestPinVC.showCancelButton = true
                 requestPinVC.onUserEnteredPin = { pin in
                     self.confirmSendWithoutPin(sendAll: false, pin: pin)

--- a/decred_wallet/view_controller/SettingsController.swift
+++ b/decred_wallet/view_controller/SettingsController.swift
@@ -219,7 +219,7 @@ class SettingsController: UITableViewController  {
 
             self.present(alert, animated: true, completion: nil)
         } else {
-            let requestPinVC = storyboard!.instantiateViewController(withIdentifier: "RequestPinViewController") as! RequestPinViewController
+            let requestPinVC = RequestPinViewController.instantiate()
             requestPinVC.securityFor = "Spending"
             requestPinVC.showCancelButton = true
             requestPinVC.onUserEnteredPin = { pin in


### PR DESCRIPTION
closes #374 
Fix crash on PIN display for send ,add account, security menu(sign menu) and settings(delete wallet)