### PR TITLE
Restart sync fix

### DIFF
--- a/decred_wallet/AppDelegate.swift
+++ b/decred_wallet/AppDelegate.swift
@@ -15,6 +15,7 @@ import Crashlytics
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
+    static var walletLoader: WalletLoader = WalletLoader()
     
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // setup crash reporting for testnet build only
@@ -39,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationWillTerminate(_: UIApplication) {
-        WalletLoader.wallet?.shutdown(true)
+        AppDelegate.walletLoader.wallet?.shutdown(true)
     }
 }
 

--- a/decred_wallet/Features/App Launch/StartScreenViewController.swift
+++ b/decred_wallet/Features/App Launch/StartScreenViewController.swift
@@ -25,7 +25,8 @@ class StartScreenViewController: UIViewController {
             testnetLabel.isHidden = false
         }
         
-        let initWalletError = WalletLoader.instance.initWallet()
+        AppDelegate.walletLoader = WalletLoader()
+        let initWalletError = AppDelegate.walletLoader.initWallet()
         if initWalletError != nil {
             print("init wallet error: \(initWalletError!.localizedDescription)")
         }
@@ -44,7 +45,7 @@ class StartScreenViewController: UIViewController {
             self.startTimerWhenViewAppears = false
         }
         
-        if WalletLoader.instance.isWalletCreated {
+        if AppDelegate.walletLoader.isWalletCreated {
             self.label.text = "Opening wallet..."
         }
     }
@@ -58,7 +59,7 @@ class StartScreenViewController: UIViewController {
     }
     
     func loadMainScreen() {
-        if !WalletLoader.instance.isWalletCreated {
+        if !AppDelegate.walletLoader.isWalletCreated {
             self.displayWalletSetupScreen()
         }
         else if StartupPinOrPassword.pinOrPasswordIsSet() {
@@ -96,7 +97,7 @@ class StartScreenViewController: UIViewController {
             guard let this = self else { return }
             
             do {
-                try WalletLoader.wallet?.open(pinOrPassword.utf8Bits)
+                try AppDelegate.walletLoader.wallet?.open(pinOrPassword.utf8Bits)
                 DispatchQueue.main.async {
                     NavigationMenuViewController.setupMenuAndLaunchApp(isNewWallet: false)
                 }

--- a/decred_wallet/Features/History/TransactionHistoryViewController.swift
+++ b/decred_wallet/Features/History/TransactionHistoryViewController.swift
@@ -43,7 +43,7 @@ class TransactionHistoryViewController: UIViewController {
         super.viewWillAppear(animated)
         self.setupNavigationBar(withTitle: "History")
 
-        if WalletLoader.isSynced {
+        if AppDelegate.walletLoader.isSynced {
             print(" wallet is synced on history")
             self.syncLabel.isHidden = true
             self.tableView.isHidden = false
@@ -51,7 +51,7 @@ class TransactionHistoryViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        if !WalletLoader.isSynced {
+        if !AppDelegate.walletLoader.isSynced {
             print(" wallet not synced on history")
             return
         }
@@ -86,7 +86,7 @@ class TransactionHistoryViewController: UIViewController {
             do {
                 var getTxsError: NSError?
                 // use limit = 0 to return all transactions
-                let jsonResponse = WalletLoader.wallet?.getTransactions(0, error: &getTxsError)
+                let jsonResponse = AppDelegate.walletLoader.wallet?.getTransactions(0, error: &getTxsError)
                 if getTxsError != nil {
                     throw getTxsError!
                 }

--- a/decred_wallet/Features/History/TransactionTableViewCell.swift
+++ b/decred_wallet/Features/History/TransactionTableViewCell.swift
@@ -26,7 +26,7 @@ class TransactionTableViewCell: BaseTableViewCell {
     override func setData(_ data: Any?) {
         
         if let transaction = data as? Transaction {
-            let bestBlock =  WalletLoader.wallet?.getBestBlock()
+            let bestBlock =  AppDelegate.walletLoader.wallet?.getBestBlock()
             var confirmations = 0
             if(transaction.Height != -1){
                 confirmations = Int(bestBlock!) - transaction.Height

--- a/decred_wallet/Features/Navigation Menu/NavigationMenuViewController.swift
+++ b/decred_wallet/Features/Navigation Menu/NavigationMenuViewController.swift
@@ -118,8 +118,8 @@ class NavigationMenuViewController: UIViewController {
         self.syncOperationProgressBar.progress = 0
         self.syncOperationProgressBar.isHidden = false
         
-        self.bestBlockLabel.text = ""
-        self.bestBlockAgeLabel.text = ""
+        self.bestBlockLabel.text = " " // use whitespace so view don't get 0 height
+        self.bestBlockAgeLabel.text = " " // use whitespace so view don't get 0 height
     }
     
     func changeActivePage(to menuItem: MenuItem) {
@@ -132,7 +132,6 @@ class NavigationMenuViewController: UIViewController {
 extension NavigationMenuViewController: SyncProgressListenerProtocol {
     func startSync() {
         self.resetSyncViews()
-        self.syncStatusLabel.text = "Connecting to peers."
         AppDelegate.walletLoader.syncer.registerSyncProgressListener(for: "\(self)", self)
         AppDelegate.walletLoader.syncer.beginSync()
     }
@@ -146,6 +145,10 @@ extension NavigationMenuViewController: SyncProgressListenerProtocol {
         
         self.resetSyncViews()
         self.syncStatusLabel.text = "Restarting sync..."
+    }
+    
+    func onStarted() {
+        self.syncStatusLabel.text = "Connecting to peers."
     }
     
     func onPeerConnectedOrDisconnected(_ numberOfConnectedPeers: Int32) {
@@ -205,8 +208,7 @@ extension NavigationMenuViewController: SyncProgressListenerProtocol {
     
     func onSyncCanceled() {
         self.resetSyncViews()
-        self.syncStatusLabel.text = "Sync canceled. Tap to restart."
-        self.syncStatusLabel.superview?.backgroundColor = UIColor.red
+        self.syncStatusLabel.text = "Sync canceled."
     }
     
     func onSyncEndedWithError(_ error: String) {

--- a/decred_wallet/Features/Overview/OverviewViewController.swift
+++ b/decred_wallet/Features/Overview/OverviewViewController.swift
@@ -19,7 +19,7 @@ class OverviewViewController: UIViewController {
     var recentTransactions = [Transaction]()
     
     override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
-        if identifier == "embedSyncProgressVC" && WalletLoader.isSynced {
+        if identifier == "embedSyncProgressVC" && AppDelegate.walletLoader.isSynced {
             return false
         }
         return true
@@ -32,7 +32,7 @@ class OverviewViewController: UIViewController {
     }
     
     override func viewDidLoad() {
-        if WalletLoader.isSynced {
+        if AppDelegate.walletLoader.isSynced {
             self.initializeOverviewContent()
         }
     }
@@ -46,8 +46,8 @@ class OverviewViewController: UIViewController {
         self.syncProgressViewContainer.removeFromSuperview()
         self.syncProgressViewContainer = nil
         
-        WalletLoader.instance.notification.registerListener(for: "\(self)", newTxistener: self)
-        WalletLoader.instance.notification.registerListener(for: "\(self)", confirmedTxListener: self)
+        AppDelegate.walletLoader.notification.registerListener(for: "\(self)", newTxistener: self)
+        AppDelegate.walletLoader.notification.registerListener(for: "\(self)", confirmedTxListener: self)
         
         self.fetchingBalanceIndicator.loadGif(name: "progress bar-1s-200px")
         self.updateCurrentBalance()
@@ -71,7 +71,7 @@ class OverviewViewController: UIViewController {
             self.fetchingBalanceIndicator.superview?.isHidden = false
             
             do {
-                let totalWalletAmount = try WalletLoader.wallet?.totalWalletBalance()
+                let totalWalletAmount = try AppDelegate.walletLoader.wallet?.totalWalletBalance()
                 let totalAmountRoundedOff = (Decimal(totalWalletAmount!) as NSDecimalNumber).round(8)
                 
                 self.totalBalanceLabel.attributedText = Utils.getAttributedString(str: "\(totalAmountRoundedOff)", siz: 17.0, TexthexColor: GlobalConstants.Colors.TextAmount)
@@ -93,7 +93,7 @@ class OverviewViewController: UIViewController {
             do {
                 var getTransactionsError: NSError?
                 let maxDisplayItems = round(self.recentActivityTableView.frame.size.height / TransactionTableViewCell.height())
-                let transactionsJson = WalletLoader.wallet?.getTransactions(Int32(maxDisplayItems), error: &getTransactionsError)
+                let transactionsJson = AppDelegate.walletLoader.wallet?.getTransactions(Int32(maxDisplayItems), error: &getTransactionsError)
                 if getTransactionsError != nil {
                     throw getTransactionsError!
                 }

--- a/decred_wallet/Features/Overview/SyncProgressViewController.swift
+++ b/decred_wallet/Features/Overview/SyncProgressViewController.swift
@@ -96,6 +96,10 @@ class SyncProgressViewController: UIViewController {
 }
 
 extension SyncProgressViewController: SyncProgressListenerProtocol {
+    func onStarted() {
+        self.syncHeaderLabel.text = "Loading..."
+    }
+    
     func onPeerConnectedOrDisconnected(_ numberOfConnectedPeers: Int32) {
         var connectedPeers: String
         if numberOfConnectedPeers == 1 {

--- a/decred_wallet/Features/Wallet Setup/WalletSetupBaseViewController.swift
+++ b/decred_wallet/Features/Wallet Setup/WalletSetupBaseViewController.swift
@@ -19,7 +19,7 @@ class WalletSetupBaseViewController: UIViewController {
         
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let this = self else { return }
-            guard let wallet = WalletLoader.wallet else { return }
+            guard let wallet = AppDelegate.walletLoader.wallet else { return }
             
             do {
                 try wallet.createWallet(pinOrPassword, seedMnemonic: seed)

--- a/decred_wallet/Features/Wallet Utils/SpendingPinOrPassword.swift
+++ b/decred_wallet/Features/Wallet Utils/SpendingPinOrPassword.swift
@@ -54,7 +54,7 @@ struct SpendingPinOrPassword {
         
         DispatchQueue.global(qos: .userInitiated).async {
             do {
-                try WalletLoader.wallet?.changePrivatePassphrase(oldPrivatePass, newPass: newPrivatePass)
+                try AppDelegate.walletLoader.wallet?.changePrivatePassphrase(oldPrivatePass, newPass: newPrivatePass)
                 DispatchQueue.main.async {
                     progressHud.dismiss()
                     UserDefaults.standard.setValue(securityType, forKey: GlobalConstants.SettingsKeys.SpendingPassphraseSecurityType)

--- a/decred_wallet/Features/Wallet Utils/StartupPinOrPassword.swift
+++ b/decred_wallet/Features/Wallet Utils/StartupPinOrPassword.swift
@@ -102,7 +102,7 @@ struct StartupPinOrPassword {
             do {
                 let oldPublicPass = (currentPublicPassphrase as NSString).data(using: String.Encoding.utf8.rawValue)!
                 let newPublicPass = (newPublicPassphrase as NSString).data(using: String.Encoding.utf8.rawValue)!
-                try WalletLoader.wallet?.changePublicPassphrase(oldPublicPass, newPass: newPublicPass)
+                try AppDelegate.walletLoader.wallet?.changePublicPassphrase(oldPublicPass, newPass: newPublicPass)
                 
                 DispatchQueue.main.async {
                     progressHud.dismiss()

--- a/decred_wallet/Features/Wallet Utils/TransactionNotification.swift
+++ b/decred_wallet/Features/Wallet Utils/TransactionNotification.swift
@@ -28,7 +28,7 @@ class TransactionNotification: NSObject {
     var newTxHashes: [String] = [String]()
     
     func startListeningForNotifications() {
-        WalletLoader.wallet?.transactionNotification(self)
+        AppDelegate.walletLoader.wallet?.transactionNotification(self)
     }
     
     func registerListener(for identifier: String, newBlockListener: NewBlockNotificationProtocol) {

--- a/decred_wallet/Features/Wallet Utils/WalletLoader.swift
+++ b/decred_wallet/Features/Wallet Utils/WalletLoader.swift
@@ -9,18 +9,14 @@
 import Foundation
 
 class WalletLoader: NSObject {
-    static let instance: WalletLoader = WalletLoader()
-    
     var wallet: DcrlibwalletLibWallet?
-    var syncer: Syncer = Syncer()
-    var notification: TransactionNotification = TransactionNotification()
+    var syncer: Syncer
+    var notification: TransactionNotification
     
-    public class var wallet: DcrlibwalletLibWallet? {
-        return instance.wallet
-    }
-    
-    public class var isSynced: Bool {
-        return instance.syncer.currentSyncOp == SyncOp.Done
+    override init() {
+        syncer = Syncer()
+        notification = TransactionNotification()
+        super.init()
     }
     
     func initWallet() -> NSError? {
@@ -30,6 +26,10 @@ class WalletLoader: NSObject {
         self.wallet = DcrlibwalletNewLibWallet(NSHomeDirectory() + "/Documents/dcrlibwallet/", "bdb", netType!, &initWalletError)
         
         return initWalletError
+    }
+    
+    var isSynced: Bool {
+        return self.syncer.currentSyncOp == SyncOp.Done
     }
     
     var isWalletCreated: Bool {
@@ -48,7 +48,7 @@ class WalletLoader: NSObject {
 extension DcrlibwalletLibWallet {
     func totalWalletBalance() throws -> Double {
         var getAccountsError: NSError?
-        let accountsJson = WalletLoader.wallet?.getAccounts(0, error: &getAccountsError)
+        let accountsJson = AppDelegate.walletLoader.wallet?.getAccounts(0, error: &getAccountsError)
         if getAccountsError != nil {
             throw getAccountsError!
         }

--- a/decred_wallet/SecurityMenuViewController.swift
+++ b/decred_wallet/SecurityMenuViewController.swift
@@ -41,12 +41,12 @@ class SecurityMenuViewController: UIViewController,UITextFieldDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        dcrlibwallet = WalletLoader.wallet
+        dcrlibwallet = AppDelegate.walletLoader.wallet
         self.address.delegate = self
         self.signature.delegate = self
         self.message.delegate = self
         
-        if WalletLoader.isSynced {
+        if AppDelegate.walletLoader.isSynced {
             self.toggleView()
         }
     }
@@ -55,7 +55,7 @@ class SecurityMenuViewController: UIViewController,UITextFieldDelegate {
         super.viewWillAppear(animated)
         self.setupNavigationBar(withTitle: "Security")
 
-        if !WalletLoader.isSynced {
+        if !AppDelegate.walletLoader.isSynced {
             syncInfoLabel.isHidden = false
             return
         }

--- a/decred_wallet/Utils.swift
+++ b/decred_wallet/Utils.swift
@@ -34,7 +34,7 @@ struct Utils {
         let int64Pointer = UnsafeMutablePointer<Int64>.allocate(capacity: 64)
         do {
             
-            try  WalletLoader.wallet?.spendable(forAccount: account.Number, requiredConfirmations: iRequireConfirm, ret0_: int64Pointer)
+            try  AppDelegate.walletLoader.wallet?.spendable(forAccount: account.Number, requiredConfirmations: iRequireConfirm, ret0_: int64Pointer)
         } catch let error{
             print(error)
             return 0.0

--- a/decred_wallet/extra_view/AccountsHeaderView/AccountsHeaderView.swift
+++ b/decred_wallet/extra_view/AccountsHeaderView/AccountsHeaderView.swift
@@ -36,7 +36,7 @@ class AccountsHeaderView: UIView {
     var spendableBalance: NSDecimalNumber = 0.0 {
         willSet {
             DispatchQueue.main.async {[weak self] in
-                if WalletLoader.isSynced {
+                if AppDelegate.walletLoader.isSynced {
                     let spendableTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor(hex: "#8997A5")]
                     let spendableTextattr =  NSMutableAttributedString(string: "Spendable ", attributes: spendableTextAttributes)
                     let amount = Utils.getAttributedString(str: "\(newValue)", siz: 9.0, TexthexColor: self!.spendableColor)

--- a/decred_wallet/table_view_cell/TransactionHistoryTableViewCell.swift
+++ b/decred_wallet/table_view_cell/TransactionHistoryTableViewCell.swift
@@ -35,7 +35,7 @@ class TransactionHistoryTableViewCell: BaseTableViewCell {
         
         if let data = data as? TransactionTableViewCellData {
             
-            let confirmation =  WalletLoader.wallet?.getBestBlock()
+            let confirmation =  AppDelegate.walletLoader.wallet?.getBestBlock()
             let confirm2 = (confirmation)! - Int32(data.trans.Height)
             
             if (confirm2 == -1) {

--- a/decred_wallet/view_controller/AccountViewController.swift
+++ b/decred_wallet/view_controller/AccountViewController.swift
@@ -75,7 +75,7 @@ class AccountViewController: UIViewController, UITableViewDataSource, UITableVie
             this.myBalances.removeAll()
             do {
                 var getAccountError: NSError?
-                let strAccount = WalletLoader.wallet?.getAccounts(0, error: &getAccountError)
+                let strAccount = AppDelegate.walletLoader.wallet?.getAccounts(0, error: &getAccountError)
                 if getAccountError != nil {
                     throw getAccountError!
                 }
@@ -133,7 +133,7 @@ class AccountViewController: UIViewController, UITableViewDataSource, UITableVie
         } else{
             headerView.arrowDirection.setImage(UIImage.init(named: "arrow-1"), for: .normal)
         }
-        headerView.syncing(status: !WalletLoader.isSynced)
+        headerView.syncing(status: !AppDelegate.walletLoader.isSynced)
         
         return headerView
     }

--- a/decred_wallet/view_controller/AddAcountViewController.swift
+++ b/decred_wallet/view_controller/AddAcountViewController.swift
@@ -71,7 +71,7 @@ class AddAcountViewController: UIViewController {
         
         DispatchQueue.global(qos: .userInitiated).async {
             do {
-                try WalletLoader.wallet?.nextAccount(accountName, privPass: passphrase)
+                try AppDelegate.walletLoader.wallet?.nextAccount(accountName, privPass: passphrase)
                 DispatchQueue.main.async {
                     progressHud.dismiss()
                     self.dismiss(animated: true, completion: nil)

--- a/decred_wallet/view_controller/ReceiveViewController.swift
+++ b/decred_wallet/view_controller/ReceiveViewController.swift
@@ -24,7 +24,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     var account: WalletAccounts?
     var tapGesture = UITapGestureRecognizer()
     var oldAddress = ""
-    var wallet = WalletLoader.wallet
+    var wallet = AppDelegate.walletLoader.wallet
     
     private var selectedAccount = ""
     

--- a/decred_wallet/view_controller/SendViewController.swift
+++ b/decred_wallet/view_controller/SendViewController.swift
@@ -78,7 +78,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         self.currencyAmount2.delegate = self
         self.pasteBtn.layer.cornerRadius = 4
         self.pasteBtn.layer.shadowOffset = CGSize(width: 0, height: 2.0)
-        wallet = WalletLoader.wallet
+        wallet = AppDelegate.walletLoader.wallet
         NotificationCenter.default.addObserver(self, selector: #selector(willResignActive), name: UIApplication.willEnterForegroundNotification, object: nil)
         self.walletAddress.delegate = self
         removedBtn = false
@@ -249,7 +249,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
     }
     
     @IBAction private func sendFund(_ sender: Any) {
-        guard WalletLoader.isSynced else {
+        guard AppDelegate.walletLoader.isSynced else {
             sendNtwkErrtext.text = "Please wait for network synchronization."
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 self.sendNtwkErrtext.text = " "
@@ -257,7 +257,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
             return
         }
         
-        guard WalletLoader.instance.syncer.connectedPeersCount > 0 else {
+        guard AppDelegate.walletLoader.syncer.connectedPeersCount > 0 else {
             sendNtwkErrtext.text = "Not connected to the network."
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 self.sendNtwkErrtext.text = " "
@@ -324,7 +324,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
     }
     
     private func signTransaction(sendAll: Bool?, password:String) {
-        guard WalletLoader.instance.syncer.connectedPeersCount > 0 else {
+        guard AppDelegate.walletLoader.syncer.connectedPeersCount > 0 else {
             sendNtwkErrtext.text = "Not connected to the network."
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 self.sendNtwkErrtext.text = " "
@@ -708,7 +708,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
                             let tmp2 = Decimal(tmp)
                             self.currencyAmount2.text = "\((((self.exchangeRateGloabal as Decimal) * tmp2)as NSDecimalNumber).round(2))"
                         }
-                        if WalletLoader.isSynced {
+                        if AppDelegate.walletLoader.isSynced {
                              self.amountErrorText.text = "Not enough funds"
                         }
                         else{
@@ -796,7 +796,7 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
                         print((tmp2 ) / (self.exchangeRateGloabal as Decimal))
                         print("currency")
                         self.tfAmount.text = "\(((tmp2 ) / (self.exchangeRateGloabal as Decimal) as NSDecimalNumber).round(8))"
-                        if WalletLoader.isSynced {
+                        if AppDelegate.walletLoader.isSynced {
                             self.amountErrorText.text = "Not enough funds"
                         }
                         else{

--- a/decred_wallet/view_controller/SettingsController.swift
+++ b/decred_wallet/view_controller/SettingsController.swift
@@ -241,7 +241,7 @@ class SettingsController: UITableViewController  {
     
     func handleDeleteWallet(pass: String){
         let progressHud = Utils.showProgressHud(withText: "Deleting wallet...")
-        let wallet = WalletLoader.wallet!
+        let wallet = AppDelegate.walletLoader.wallet!
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let this = self else { return }
             

--- a/decred_wallet/view_controller/SettingsController.swift
+++ b/decred_wallet/view_controller/SettingsController.swift
@@ -242,14 +242,13 @@ class SettingsController: UITableViewController  {
     func handleDeleteWallet(pass: String){
         let progressHud = Utils.showProgressHud(withText: "Deleting wallet...")
         let wallet = AppDelegate.walletLoader.wallet!
+        
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let this = self else { return }
             
             do {
-                let passData = (pass as NSString).data(using: String.Encoding.utf8.rawValue)!
-                wallet.cancelSync()
-                try wallet.unlock(passData)
-                try wallet.close()
+                try wallet.unlock(pass.utf8Bits)
+                wallet.shutdown(true)
 
                 let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
                 let walletDir = paths[0].appendingPathComponent("dcrlibwallet")

--- a/decred_wallet/view_controller/TransactionFullDetails/Cells/TransactiontOutputDetailsCell.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/Cells/TransactiontOutputDetailsCell.swift
@@ -22,7 +22,7 @@ class TransactiontOutputDetailsCell: UITableViewCell {
         
         var walletOutputIndices = [Int]()
         
-        let wallet = WalletLoader.wallet
+        let wallet = AppDelegate.walletLoader.wallet
         
         for (_, credit) in credits.enumerated() {
             walletOutputIndices.append(Int(credit.Index))

--- a/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
+++ b/decred_wallet/view_controller/TransactionFullDetails/TransactionFullDetailsViewController.swift
@@ -63,7 +63,7 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         do {
             if let data = Data(fromHexEncodedString: self.transaction.Hash) {
                 var decodeTxError: NSError?
-                let decodedTxJson = WalletLoader.wallet?.decodeTransaction(data, error: &decodeTxError)
+                let decodedTxJson = AppDelegate.walletLoader.wallet?.decodeTransaction(data, error: &decodeTxError)
                 if decodeTxError != nil {
                     throw decodeTxError!
                 }
@@ -200,7 +200,7 @@ class TransactionFullDetailsViewController: UIViewController, UITableViewDataSou
         let textColor: UIColor?
         
         if(transaction!.Height != -1){
-            confirmations = (WalletLoader.wallet?.getBestBlock())! - Int32(transaction!.Height)
+            confirmations = (AppDelegate.walletLoader.wallet?.getBestBlock())! - Int32(transaction!.Height)
             confirmations += 1
         }
         


### PR DESCRIPTION
Resolves #381. Requires https://github.com/raedahgroup/dcrlibwallet/pull/27.
- Restarts sync when sync status label (on nav menu) is tapped
- Shows proper messages on nav menu and overview when sync is canceled or an error occurs during sync.
- Sync appears to be momentarily canceled (restarted) if the app loses internet connection, gets reconnected and connection to peers is reestablished. This PR fixes the momentary (but unpleasant) UI change noticed on the nav menu when this happens. 