### PR TITLE
Hide debug sync info on tap, fix send page crash, tap to copy on receive

### DIFF
--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -555,9 +555,9 @@
 		B3B469EF228F0F2600A68EDD /* Overview */ = {
 			isa = PBXGroup;
 			children = (
-				B3B469F0228F0F2600A68EDD /* SyncProgressViewController.swift */,
-				B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */,
 				B3B469F2228F0F2600A68EDD /* Overview.storyboard */,
+				B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */,
+				B3B469F0228F0F2600A68EDD /* SyncProgressViewController.swift */,
 			);
 			path = Overview;
 			sourceTree = "<group>";

--- a/Decred Wallet/Base.lproj/Main.storyboard
+++ b/Decred Wallet/Base.lproj/Main.storyboard
@@ -256,24 +256,18 @@
                                             <constraint firstAttribute="height" constant="1" id="7P5-K4-rt5"/>
                                         </constraints>
                                     </view>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="P2Q-l4-CRY">
+                                    <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="P2Q-l4-CRY">
                                         <rect key="frame" x="0.0" y="112" width="355" height="355"/>
                                         <gestureRecognizers/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="P2Q-l4-CRY" secondAttribute="height" multiplier="1:1" id="RAZ-q2-eSQ"/>
                                         </constraints>
-                                        <connections>
-                                            <outletCollection property="gestureRecognizers" destination="83B-mb-51W" appends="YES" id="5k8-Yq-9To"/>
-                                        </connections>
                                     </imageView>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ad3-va-aFy">
                                         <rect key="frame" x="0.0" y="469" width="355" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.016995774582028389" green="0.48766422271728516" blue="0.99898439645767212" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
-                                        <connections>
-                                            <outletCollection property="gestureRecognizers" destination="83B-mb-51W" appends="YES" id="jAr-Dw-ZFj"/>
-                                        </connections>
                                     </label>
                                     <label opaque="NO" contentMode="left" text="(Copy on tap)" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KIw-9c-4KG">
                                         <rect key="frame" x="0.0" y="491.5" width="355" height="21.5"/>
@@ -308,11 +302,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="R0Q-i3-kfU" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="83B-mb-51W">
-                    <connections>
-                        <action selector="CopyImgAddress:" destination="pwN-Wv-Ioh" id="rEz-vV-Jnr"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-406" y="814"/>
         </scene>
@@ -1117,7 +1106,7 @@
         <!--Confirm To Send Fund ViewPIN Controller-->
         <scene sceneID="T1Z-xm-Luy">
             <objects>
-                <viewController storyboardIdentifier="ConfirmToSendFundViewPINController" id="wsz-Ml-THI" customClass="ConfirmToSendFundViewPINController" customModule="DecredWallet" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ConfirmToSendFundViewPINController" id="wsz-Ml-THI" customClass="ConfirmToSendFundViewPINController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="e0s-OP-9cj"/>
                         <viewControllerLayoutGuide type="bottom" id="Jyv-KV-Dxo"/>

--- a/Decred Wallet/Features/Overview/SyncProgressViewController.swift
+++ b/Decred Wallet/Features/Overview/SyncProgressViewController.swift
@@ -70,6 +70,7 @@ class SyncProgressViewController: UIViewController {
         UIView.animate(withDuration: 0.1, animations: { () -> Void in
             self.showDetailedSyncReportButton.isHidden = false
             self.currentSyncActionReportLabel.isHidden = true
+            self.debugSyncInfoLabel.isHidden = true
             self.connectedPeersLabel.isHidden = true
         })
     }

--- a/Decred Wallet/view_controller/ReceiveViewController.swift
+++ b/Decred Wallet/view_controller/ReceiveViewController.swift
@@ -38,14 +38,26 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         self.starttime = Int64(NSDate().timeIntervalSince1970)
     }
     
-    func setupExtraUI(){
-        tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.CopyImgAddress(_:)))
-        tapGesture.numberOfTapsRequired = 1
-        tapGesture.numberOfTouchesRequired = 1
-        imgWalletAddrQRCode.addGestureRecognizer(tapGesture)
-        imgWalletAddrQRCode.isUserInteractionEnabled = true
+    func setupExtraUI() {
+        self.imgWalletAddrQRCode.addGestureRecognizer(tapToCopyAddressGesture())
+        self.lblWalletAddress.addGestureRecognizer(tapToCopyAddressGesture())
         self.accountDropdown.backgroundColor = UIColor.white
-        
+    }
+    
+    func tapToCopyAddressGesture() -> UITapGestureRecognizer {
+        return UITapGestureRecognizer(target: self, action: #selector(self.copyAddress))
+    }
+    
+    @objc func copyAddress() {
+        DispatchQueue.main.async {
+            //Copy a string to the pasteboard.
+            UIPasteboard.general.string = self.lblWalletAddress.text!
+            
+            //Alert
+            let alertController = UIAlertController(title: "", message: "Wallet address copied", preferredStyle: UIAlertController.Style.alert)
+            alertController.addAction(UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: nil))
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -61,11 +73,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         self.navigationItem.rightBarButtonItems = [barButton!, shareBtn ]
     }
     
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
-    
-    @objc func showMenu(sender: Any){
+    @objc func showMenu(sender: Any) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
@@ -89,14 +97,9 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         self.getNextAddress(accountNumber: (self.myacc.Number))
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-    }
-    
     private func showFirstWalletAddressAndQRCode() {
-        
         self.account?.Acc.removeAll()
-        do{
+        do {
             var getAccountError: NSError?
             let strAccount = self.wallet?.getAccounts(0, error: &getAccountError)
             if getAccountError != nil {
@@ -123,26 +126,9 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
         }
     }
     
-    @IBAction func CopyImgAddress(_ sender: UITapGestureRecognizer) {
-        self.copyAddress()
-    }
-    
-    private func copyAddress() {
-        DispatchQueue.main.async {
-            //Copy a string to the pasteboard.
-            UIPasteboard.general.string = self.lblWalletAddress.text!
-            
-            //Alert
-            let alertController = UIAlertController(title: "", message: "Wallet address copied", preferredStyle: UIAlertController.Style.alert)
-            alertController.addAction(UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: nil))
-            self.present(alertController, animated: true, completion: nil)
-        }
-    }
-    
     private func populateWalletDropdownMenu() {
-        
         self.account?.Acc.removeAll()
-        do{
+        do {
             var getAccountError: NSError?
             let strAccount = self.wallet?.getAccounts(0, error: &getAccountError)
             if getAccountError != nil {

--- a/Decred Wallet/view_controller/SendViewController.swift
+++ b/Decred Wallet/view_controller/SendViewController.swift
@@ -357,8 +357,10 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
                         self.transactionSucceeded(hash: result?.hexEncodedString())
                     }
                 } catch let error {
-                    progressHud.dismiss()
-                    self.showAlert(message: error.localizedDescription, titles: "Error")
+                    DispatchQueue.main.async {
+                        progressHud.dismiss()
+                        self.showAlert(message: error.localizedDescription, titles: "Error")
+                    }
                 }
             }
         }

--- a/Decred Wallet/view_controller/SendViewController.swift
+++ b/Decred Wallet/view_controller/SendViewController.swift
@@ -349,7 +349,6 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
             let progressHud = Utils.showProgressHud(withText: "Sending Transaction...")
             DispatchQueue.global(qos: .userInitiated).async {[unowned self] in
                 do {
-                    
                     let isShouldBeConfirmed = UserDefaults.standard.bool(forKey: "pref_spend_fund_switch")
                     let result = try self.wallet?.sendTransaction(password.data(using: .utf8), destAddr: walletAddress, amount: Int64(amount) , srcAccount: account , requiredConfs: isShouldBeConfirmed ? 0 : 2, sendAll: sendAll ?? false)
                     
@@ -371,7 +370,6 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
     }
     
     private func confirmSend(sendAll: Bool) {
-        
         let amountToSend = (tfAmount?.text)!
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         
@@ -412,48 +410,42 @@ class SendViewController: UIViewController, UITextFieldDelegate,UITextPasteDeleg
         DispatchQueue.main.async {
             self.present(confirmSendFundViewController, animated: true, completion: nil)
         }
-        return
     }
     
     private func confirmSendWithoutPin(sendAll: Bool, pin: String) {
-        let amountToSend = (tfAmount?.text)!
-        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        
-        let confirmSendFundViewController = storyboard.instantiateViewController(withIdentifier: "ConfirmToSendFundViewPINController") as! ConfirmToSendFundViewPINController
+        let confirmSendFundViewController = Storyboards.Main.instantiateViewController(for: ConfirmToSendFundViewPINController.self)
         confirmSendFundViewController.modalTransitionStyle = .crossDissolve
         confirmSendFundViewController.modalPresentationStyle = .overCurrentContext
         
         let tap = UITapGestureRecognizer(target: confirmSendFundViewController.view, action: #selector(confirmSendFundViewController.vContent.endEditing(_:)))
         tap.cancelsTouchesInView = false
-        
         confirmSendFundViewController.view.addGestureRecognizer(tap)
-        DispatchQueue.main.async {
-            if (self.toAddressContainer.isHidden){
-                let receiveAddress = self.wallet?.currentAddress((self.sendToAccount?.Number)!, error: nil)
-                confirmSendFundViewController.address = receiveAddress!
-                confirmSendFundViewController.account = (self.selectedAccount?.Name)!
-            }
-            else{
-                confirmSendFundViewController.accountName.isHidden = true
-                confirmSendFundViewController.address = self.walletAddress.text!
-            }
-            if !(self.conversionRowCont.isHidden){
-                confirmSendFundViewController.amount = "\(amountToSend) DCR ($\((self.currencyAmount2.text)!))"
-                confirmSendFundViewController.fee = "\((self.estimateFee.text)!) ($\((self.tempFee)))"
-            }
-            else{
-                confirmSendFundViewController.amount = "\(amountToSend) DCR"
-                confirmSendFundViewController.fee = "\((self.estimateFee.text)!) (\((self.estimateSize.text)!))"
-            }
+        
+        if (self.toAddressContainer.isHidden) {
+            let receiveAddress = self.wallet?.currentAddress((self.sendToAccount?.Number)!, error: nil)
+            confirmSendFundViewController.address = receiveAddress!
+            confirmSendFundViewController.account = (self.selectedAccount?.Name)!
+        } else {
+            confirmSendFundViewController.accountName.isHidden = true
+            confirmSendFundViewController.address = self.walletAddress.text!
         }
-        let tmp = pin
+        
+        let amountToSend = (self.tfAmount?.text)!
+        if !(self.conversionRowCont.isHidden) {
+            confirmSendFundViewController.amount = "\(amountToSend) DCR ($\((self.currencyAmount2.text)!))"
+            confirmSendFundViewController.fee = "\((self.estimateFee.text)!) ($\((self.tempFee)))"
+        } else {
+            confirmSendFundViewController.amount = "\(amountToSend) DCR"
+            confirmSendFundViewController.fee = "\((self.estimateFee.text)!) (\((self.estimateSize.text)!))"
+        }
+
         confirmSendFundViewController.confirm = { () in
-            self.signTransaction(sendAll: sendAll, password: tmp)
+            self.signTransaction(sendAll: sendAll, password: pin)
         }
+        
         DispatchQueue.main.async {
             self.present(confirmSendFundViewController, animated: true, completion: nil)
         }
-        return
     }
     
     @IBAction private func scanQRCodeAction(_ sender: UIButton) {


### PR DESCRIPTION
Resolves #394: Debug sync info is hidden along with other detailed sync information on tap.
Resolves #395: Receive page tap address text and qr image to copy generated address.
Part fix for #403: Send page crash after entering PIN.