### PR TITLE
correct status for new tx in overview/history, correct pin/pass active tab border

### DIFF
--- a/Decred Wallet/Features/History/TransactionTableViewCell.swift
+++ b/Decred Wallet/Features/History/TransactionTableViewCell.swift
@@ -35,7 +35,7 @@ class TransactionTableViewCell: BaseTableViewCell {
             
             let spendUnconfirmedFunds = UserDefaults.standard.bool(forKey: "pref_spend_fund_switch")
             
-            if (confirmations == -1) {
+            if (transaction.Height == -1) {
                 self.status.textColor = UIColor(hex:"#3d659c")
                 self.status.text = "Pending"
             } else {

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -70,19 +70,19 @@ class SecurityViewController: SecurityBaseViewController {
         tabController?.selectedIndex = 0
         // activate password button
         btnPassword.backgroundColor = UIColor.appColors.offWhite
-        btnPassword.addBorders(atPositions: [.right, .bottom])
+        btnPassword.removeBorders(atPositions: .right, .bottom)
         // deactivate pin button
         btnPin.backgroundColor = UIColor.white
-        btnPin.removeBorders(atPositions: .left, .bottom)
+        btnPin.addBorders(atPositions: [.left, .bottom])
     }
     
     func activatePinTab() {
         tabController?.selectedIndex = 1
         // activate pin button
         btnPin.backgroundColor = UIColor.appColors.offWhite
-        btnPin.addBorders(atPositions: [.left, .bottom])
+        btnPin.removeBorders(atPositions: .left, .bottom)
         // deactivate password button
         btnPassword.backgroundColor = UIColor.white
-        btnPassword.removeBorders(atPositions: .right, .bottom)
+        btnPassword.addBorders(atPositions: [.right, .bottom])
     }
 }


### PR DESCRIPTION
New txs (0 confirmations) incorrectly show as Confirmed in overview and history page, but show correctly as Pending in tx details page.

Resolves #424:
<img width="300" alt="Screenshot 2019-05-29 at 6 08 19 AM" src="https://user-images.githubusercontent.com/18400051/58530880-45793080-81d8-11e9-9b8c-357df8af7ad8.png">
