### PR TITLE
updates to support latest sync changes on dcrlibwallet/master

### DIFF
--- a/Decred Wallet/Features/Wallet Utils/Syncer.swift
+++ b/Decred Wallet/Features/Wallet Utils/Syncer.swift
@@ -54,7 +54,9 @@ class Syncer: NSObject, AppLifeCycleDelegate {
     
     func registerEstimatedSyncProgressListener() {
         AppDelegate.walletLoader.wallet?.enableSyncLogs()
-        try! AppDelegate.walletLoader.wallet?.add(self, uniqueIdentifier: "dcrios")
+        // Following call should only throw an error if we attempt to add this sync progress listener multiple times.
+        // Safe to ignore such error since it implies that this sync listener is already registered.
+        try? AppDelegate.walletLoader.wallet?.add(self, uniqueIdentifier: "dcrios")
     }
     
     func beginSync() {

--- a/Decred Wallet/Features/Wallet Utils/Syncer.swift
+++ b/Decred Wallet/Features/Wallet Utils/Syncer.swift
@@ -53,7 +53,8 @@ class Syncer: NSObject, AppLifeCycleDelegate {
     }
     
     func registerEstimatedSyncProgressListener() {
-        AppDelegate.walletLoader.wallet?.add(self, logEstimatedProgress: true)
+        AppDelegate.walletLoader.wallet?.enableSyncLogs()
+        try! AppDelegate.walletLoader.wallet?.add(self, uniqueIdentifier: "dcrios")
     }
     
     func beginSync() {
@@ -181,7 +182,7 @@ class Syncer: NSObject, AppLifeCycleDelegate {
 
 // Extension for receiving estimated sync progress report from dcrlibwallet sync process.
 // Progress report is decoded from the received Json string back to the original data format in the same dcrlibwallet background thread.
-extension Syncer: DcrlibwalletEstimatedSyncProgressListenerProtocol {
+extension Syncer: DcrlibwalletSyncProgressListenerProtocol {
     func onPeerConnectedOrDisconnected(_ numberOfConnectedPeers: Int32) {
         self.connectedPeersCount = numberOfConnectedPeers
         self.forEachSyncListener({ syncListener in syncListener.onPeerConnectedOrDisconnected(numberOfConnectedPeers) })


### PR DESCRIPTION
Incorporate dcrlibwallet sync improvements from https://github.com/raedahgroup/dcrlibwallet/pull/31 (merged into dcrlibwallet/master).

`dcrlibwallet/master` causes crashes on dcrios, crashes are fixed in https://github.com/raedahgroup/dcrlibwallet/pull/37. For crash-free experience, generate dcrlibwallet.framework from https://github.com/raedahgroup/dcrlibwallet/pull/37 instead of master.

Other than those crashes, sync should work as expected.