### PR TITLE
fix send max button to exhibit consistent behaviour

### DIFF
--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		7D66B4CA3456FF02B98D7834 /* Pods_Decred_Wallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A4F4B4098858CBBF8CB6882 /* Pods_Decred_Wallet.framework */; };
 		B36255B622A11A9500C62946 /* SecurityMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36255B422A11A9500C62946 /* SecurityMenuViewController.swift */; };
 		B36255B722A11A9500C62946 /* SecurityMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B36255B522A11A9500C62946 /* SecurityMenu.storyboard */; };
+		B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3635B81229FE5870052EB4D /* QRImageScanner.swift */; };
 		B36EFD362298617C002753B2 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36EFD352298617C002753B2 /* UIButton.swift */; };
 		B377DB0722A5663700BDF56F /* DeleteWalletConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */; };
 		B3967B3D22A75BD400E14432 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3967B3C22A75BD400E14432 /* UITableView.swift */; };
@@ -146,6 +147,7 @@
 		6FE71B33B4D10159ABF72715 /* Pods-Decred Wallet.testnet debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet debug.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet debug.xcconfig"; sourceTree = "<group>"; };
 		B36255B422A11A9500C62946 /* SecurityMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityMenuViewController.swift; sourceTree = "<group>"; };
 		B36255B522A11A9500C62946 /* SecurityMenu.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SecurityMenu.storyboard; sourceTree = "<group>"; };
+		B3635B81229FE5870052EB4D /* QRImageScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRImageScanner.swift; sourceTree = "<group>"; };
 		B36EFD352298617C002753B2 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
 		B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteWalletConfirmationViewController.swift; sourceTree = "<group>"; };
 		B3967B3C22A75BD400E14432 /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			isa = PBXGroup;
 			children = (
 				B3B469AD228F0F2600A68EDD /* Button.swift */,
+				B3635B81229FE5870052EB4D /* QRImageScanner.swift */,
 			);
 			path = "Custom Views";
 			sourceTree = "<group>";
@@ -902,6 +905,7 @@
 				B3B46AB3228F0F7D00A68EDD /* ConfirmSeedViewCell.swift in Sources */,
 				B3B46A88228F0F7D00A68EDD /* UIIMage.swift in Sources */,
 				B3B46A11228F0F2700A68EDD /* UITableViewExtension.swift in Sources */,
+				B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */,
 				B3B46A2E228F0F2700A68EDD /* MenuItem.swift in Sources */,
 				B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */,
 				B36EFD362298617C002753B2 /* UIButton.swift in Sources */,

--- a/Decred Wallet/Custom Views/QRImageScanner.swift
+++ b/Decred Wallet/Custom Views/QRImageScanner.swift
@@ -1,0 +1,44 @@
+//
+//  QRImageScanner.swift
+//  Decred Wallet
+//
+//  Created by Wisdom Arerosuoghene on 30/05/2019.
+//  Copyright © 2019 Decred. All rights reserved.
+//
+
+import QRCodeReader
+
+// Good practice: create an instance of QRImageScanner lazily to avoid cpu overload during the
+// initialization and each time we need to scan a QRCode.
+class QRImageScanner: NSObject, QRCodeReaderViewControllerDelegate {
+    private var qrCodeReaderVC: QRCodeReaderViewController = {
+        let builder = QRCodeReaderViewControllerBuilder {
+            $0.reader = QRCodeReader(metadataObjectTypes: [.qr], captureDevicePosition: .back)
+        }
+        return QRCodeReaderViewController(builder: builder)
+    }()
+    
+    var sender: UIViewController?
+    
+    override init() {
+        super.init()
+        qrCodeReaderVC.delegate = self
+        qrCodeReaderVC.modalPresentationStyle = .formSheet
+    }
+    
+    func scan(sender: UIViewController, onTextScanned: ((String?) -> Void)?) {
+        self.sender = sender
+        self.qrCodeReaderVC.completionBlock = { onTextScanned?($0?.value) }
+        sender.present(qrCodeReaderVC, animated: true, completion: nil)
+    }
+    
+    func reader(_ reader: QRCodeReaderViewController, didScanResult result: QRCodeReaderResult) {
+        reader.stopScanning()
+        self.sender?.dismiss(animated: true, completion: nil)
+    }
+    
+    func readerDidCancel(_ reader: QRCodeReaderViewController) {
+        reader.stopScanning()
+        self.sender?.dismiss(animated: true, completion: nil)
+    }
+}

--- a/Decred Wallet/Features/Navigation Menu/NavigationMenuViewController.swift
+++ b/Decred Wallet/Features/Navigation Menu/NavigationMenuViewController.swift
@@ -124,7 +124,7 @@ class NavigationMenuViewController: UIViewController {
     
     func syncNotStartedDueToNetwork() {
         AppDelegate.walletLoader.syncer.deRegisterSyncProgressListener(for: "\(self)")
-        AppDelegate.walletLoader.wallet?.cancelSync() // Cancel any previous/ongoing sync process.
+        AppDelegate.walletLoader.wallet?.cancelSync(false) // Cancel any previous/ongoing sync process without losing peers.
         
         // Allow 0.5 seconds for sync cancellation to complete before setting up wallet.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/Decred Wallet/Features/Send/Send.storyboard
+++ b/Decred Wallet/Features/Send/Send.storyboard
@@ -33,38 +33,38 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D95-MR-kWM">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="536.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="520"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Sending Decred" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Faq-Q1-1jw">
-                                                        <rect key="frame" x="10" y="10" width="394" height="25.5"/>
+                                                        <rect key="frame" x="10" y="10" width="394" height="23.5"/>
                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                                         <color key="textColor" red="0.043137254899999998" green="0.1137254902" blue="0.2470588235" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Input or scan the destination wallet address and the amount in DCR to send funds." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="B9S-LZ-TVR">
-                                                        <rect key="frame" x="10" y="40.5" width="394" height="43"/>
+                                                        <rect key="frame" x="10" y="38.5" width="394" height="40"/>
                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="17"/>
                                                         <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" verticalHuggingPriority="300" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="vIN-ec-TtI">
-                                                        <rect key="frame" x="10" y="88.5" width="394" height="10"/>
+                                                        <rect key="frame" x="10" y="83.5" width="394" height="10"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="10" id="iQF-gk-WAH"/>
                                                         </constraints>
                                                     </view>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KRc-5F-cZv">
-                                                        <rect key="frame" x="10" y="103.5" width="394" height="36"/>
+                                                        <rect key="frame" x="10" y="98.5" width="394" height="35"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="From:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BJ7-vY-Rh4">
-                                                                <rect key="frame" x="0.0" y="0.0" width="44" height="36"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="47" height="35"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="fill" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TW4-eL-kcD" customClass="DropMenuButton" customModule="Decred_Wallet" customModuleProvider="target">
-                                                                <rect key="frame" x="54" y="0.0" width="306" height="36"/>
+                                                                <rect key="frame" x="57" y="0.0" width="303" height="35"/>
                                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="19"/>
                                                                 <state key="normal" title="default">
@@ -72,29 +72,29 @@
                                                                 </state>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QBh-io-GuA">
-                                                                <rect key="frame" x="370" y="0.0" width="24" height="36"/>
+                                                                <rect key="frame" x="370" y="0.0" width="24" height="35"/>
                                                                 <state key="normal" image="arrow-1"/>
                                                             </button>
                                                         </subviews>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B61-sr-VbL">
-                                                        <rect key="frame" x="10" y="144.5" width="394" height="1"/>
+                                                        <rect key="frame" x="10" y="138.5" width="394" height="1"/>
                                                         <color key="backgroundColor" red="0.83921568629999999" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="6zY-Xc-y67"/>
                                                         </constraints>
                                                     </view>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="x14-2b-V24">
-                                                        <rect key="frame" x="10" y="148" width="394" height="0.0"/>
+                                                        <rect key="frame" x="10" y="142" width="394" height="0.0"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nTE-5s-q9a">
-                                                                <rect key="frame" x="0.0" y="0.0" width="44" height="0.0"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="47" height="0.0"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="fill" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aAT-RT-mQt" customClass="DropMenuButton" customModule="Decred_Wallet" customModuleProvider="target">
-                                                                <rect key="frame" x="54" y="0.0" width="306" height="0.0"/>
+                                                                <rect key="frame" x="57" y="0.0" width="303" height="0.0"/>
                                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="19"/>
                                                                 <state key="normal" title="other account">
@@ -108,16 +108,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XhJ-Li-bO8">
-                                                        <rect key="frame" x="10" y="150.5" width="394" height="36"/>
+                                                        <rect key="frame" x="10" y="144.5" width="394" height="36"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="740" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Destination Address" textAlignment="natural" minimumFontSize="12" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="fmU-vc-JfS">
-                                                                <rect key="frame" x="0.0" y="8.5" width="253.5" height="19"/>
+                                                                <rect key="frame" x="0.0" y="8.5" width="247.5" height="19"/>
                                                                 <color key="textColor" red="0.2901960784" green="0.57254901960000004" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="15"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Epn-J1-AU1" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                                                <rect key="frame" x="257.5" y="3" width="99.5" height="30.5"/>
+                                                                <rect key="frame" x="251.5" y="3" width="105.5" height="30.5"/>
                                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.10474636129999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="14"/>
                                                                 <inset key="contentEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
@@ -147,41 +147,41 @@
                                                         </constraints>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Icq-b5-W8t">
-                                                        <rect key="frame" x="10" y="191.5" width="394" height="1"/>
+                                                        <rect key="frame" x="10" y="185.5" width="394" height="1"/>
                                                         <color key="backgroundColor" red="0.83921568629999999" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="QiY-zN-pU8"/>
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Destination address/account error." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pli-UL-ZFR">
-                                                        <rect key="frame" x="10" y="197.5" width="394" height="13.5"/>
+                                                        <rect key="frame" x="10" y="191.5" width="394" height="13.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                         <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="dCp-0P-XTd">
-                                                        <rect key="frame" x="10" y="216" width="394" height="47"/>
+                                                        <rect key="frame" x="10" y="210" width="394" height="44"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" axis="vertical" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="gVD-v7-9Od">
-                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="47"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="44"/>
                                                                 <subviews>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="cHa-93-8da">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="19"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="760" text="Send in DCR:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lmg-HG-7hD">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="85.5" height="20.5"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="97" height="19"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="0.32167701199999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0.00" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="1U9-em-9hq">
-                                                                                <rect key="frame" x="91.5" y="0.0" width="202.5" height="20.5"/>
+                                                                                <rect key="frame" x="103" y="0.0" width="186" height="19"/>
                                                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                                                             </textField>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="760" text="DCR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="idu-UL-5ak">
-                                                                                <rect key="frame" x="300" y="0.0" width="25" height="20.5"/>
+                                                                                <rect key="frame" x="295" y="0.0" width="30" height="19"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                 <color key="textColor" red="0.044250898060000002" green="0.11294751610000001" blue="0.24704176189999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -189,22 +189,22 @@
                                                                         </subviews>
                                                                     </stackView>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="7KC-Bj-qJ8">
-                                                                        <rect key="frame" x="0.0" y="26.5" width="325" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="25" width="325" height="19"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="760" text="Send in USD:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MtL-NN-z1d">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="86" height="20.5"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="96.5" height="19"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="0.32167701199999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0.00" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="0Hu-AH-gLY">
-                                                                                <rect key="frame" x="92" y="0.0" width="202" height="20.5"/>
+                                                                                <rect key="frame" x="102.5" y="0.0" width="187" height="19"/>
                                                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                                                             </textField>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="760" text="USD" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OnJ-gB-4EK">
-                                                                                <rect key="frame" x="300" y="0.0" width="25" height="20.5"/>
+                                                                                <rect key="frame" x="295.5" y="0.0" width="29.5" height="19"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                 <color key="textColor" red="0.044250898060000002" green="0.11294751610000001" blue="0.24704176189999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -214,7 +214,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="260" horizontalCompressionResistancePriority="760" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gwT-NE-TAu">
-                                                                <rect key="frame" x="331" y="0.0" width="63" height="47"/>
+                                                                <rect key="frame" x="331" y="0.0" width="63" height="44"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <state key="normal" title="SEND MAX">
                                                                     <color key="titleColor" red="0.53725490200000003" green="0.59215686270000001" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -226,36 +226,36 @@
                                                         </subviews>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GRd-i7-9J1">
-                                                        <rect key="frame" x="10" y="268" width="394" height="1"/>
+                                                        <rect key="frame" x="10" y="259" width="394" height="1"/>
                                                         <color key="backgroundColor" red="0.83921568629999999" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="5Bd-cV-iAq"/>
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Send amount error." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3up-Cv-sq1">
-                                                        <rect key="frame" x="10" y="274" width="394" height="13.5"/>
+                                                        <rect key="frame" x="10" y="265" width="394" height="13.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                         <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" verticalHuggingPriority="300" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="RsQ-uZ-fOt">
-                                                        <rect key="frame" x="10" y="292.5" width="394" height="10"/>
+                                                        <rect key="frame" x="10" y="283.5" width="394" height="10"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="10" id="pfJ-tD-niR"/>
                                                         </constraints>
                                                     </view>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="nZ6-FA-IQR">
-                                                        <rect key="frame" x="10" y="307.5" width="394" height="40.5"/>
+                                                        <rect key="frame" x="10" y="298.5" width="394" height="37.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="Fee:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="81f-yu-bbm">
-                                                                <rect key="frame" x="0.0" y="0.0" width="101" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="113" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="0.00 DCR (0 USD)" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75s-Rm-5ou">
-                                                                <rect key="frame" x="121" y="0.0" width="273" height="40.5"/>
+                                                                <rect key="frame" x="133" y="0.0" width="261" height="37.5"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -263,16 +263,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="bBD-0D-2Gb">
-                                                        <rect key="frame" x="10" y="353" width="394" height="20.5"/>
+                                                        <rect key="frame" x="10" y="341" width="394" height="19"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="Estimate Size:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CDU-t3-vJE">
-                                                                <rect key="frame" x="0.0" y="0.0" width="101" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="113" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="0 Bytes" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xr5-75-Znk">
-                                                                <rect key="frame" x="121" y="0.0" width="273" height="20.5"/>
+                                                                <rect key="frame" x="133" y="0.0" width="261" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -280,16 +280,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="YPb-uM-h4p">
-                                                        <rect key="frame" x="10" y="378.5" width="394" height="20.5"/>
+                                                        <rect key="frame" x="10" y="365" width="394" height="19"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="Balance After:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lWP-tU-Apf">
-                                                                <rect key="frame" x="0.0" y="0.0" width="101" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="113" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="0.00 DCR" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mdf-dJ-hd3">
-                                                                <rect key="frame" x="121" y="0.0" width="273" height="20.5"/>
+                                                                <rect key="frame" x="133" y="0.0" width="261" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -297,16 +297,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="MsL-22-3SP">
-                                                        <rect key="frame" x="10" y="404" width="394" height="20.5"/>
+                                                        <rect key="frame" x="10" y="389" width="394" height="19"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" text="Exchange Rate:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DYr-F9-rbe">
-                                                                <rect key="frame" x="0.0" y="0.0" width="101" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="113" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="0.00 USD/DCR (bittrex)" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="luA-E9-MFf">
-                                                                <rect key="frame" x="121" y="0.0" width="273" height="20.5"/>
+                                                                <rect key="frame" x="133" y="0.0" width="261" height="19"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                 <color key="textColor" red="0.3803921569" green="0.45098039220000002" blue="0.52549019610000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -314,7 +314,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" contentMode="left" text="Bittrex rate unavailable (tap to retry)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z88-ft-ADH">
-                                                        <rect key="frame" x="10" y="429.5" width="394" height="13.5"/>
+                                                        <rect key="frame" x="10" y="413" width="394" height="13.5"/>
                                                         <gestureRecognizers/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                         <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -324,20 +324,20 @@
                                                         </connections>
                                                     </label>
                                                     <view contentMode="scaleToFill" verticalHuggingPriority="300" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="2BV-g4-rV8">
-                                                        <rect key="frame" x="10" y="448" width="394" height="10"/>
+                                                        <rect key="frame" x="10" y="431.5" width="394" height="10"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="10" id="Zsj-V0-0cR"/>
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Send error." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="obt-Ce-zGu">
-                                                        <rect key="frame" x="10" y="463" width="394" height="13.5"/>
+                                                        <rect key="frame" x="10" y="446.5" width="394" height="13.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                         <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yo6-bI-Tb7">
-                                                        <rect key="frame" x="10" y="481.5" width="394" height="45"/>
+                                                        <rect key="frame" x="10" y="465" width="394" height="45"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e0G-3u-NZN" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
                                                                 <rect key="frame" x="157" y="0.0" width="80" height="45"/>
@@ -570,11 +570,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tAx-AK-WJr">
-                                <rect key="frame" x="57" y="354" width="300" height="238"/>
+                                <rect key="frame" x="57" y="348.5" width="300" height="249"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="7Mi-Uh-wwu">
-                                <rect key="frame" x="57" y="354" width="300" height="188"/>
+                                <rect key="frame" x="57" y="348.5" width="300" height="199"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="img-tx-sent" translatesAutoresizingMaskIntoConstraints="NO" id="cqu-9T-Zgo">
                                         <rect key="frame" x="12" y="12" width="276" height="60"/>
@@ -583,19 +583,19 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Transaction successful" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wcg-4h-BAr">
-                                        <rect key="frame" x="12" y="78" width="276" height="26.5"/>
+                                        <rect key="frame" x="12" y="78" width="276" height="24.5"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="21"/>
                                         <color key="textColor" red="0.2274509804" green="0.84313725490000002" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="HASH:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OBe-N1-fbi">
-                                        <rect key="frame" x="12" y="110.5" width="276" height="21.5"/>
+                                        <rect key="frame" x="12" y="108.5" width="276" height="20"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="17"/>
                                         <color key="textColor" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="ADSFASDFSDADSFASDFSDADSFASDFSDADSFASDFSDADSFASDFSDADSFASDFSD" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cs8-5g-jzH">
-                                        <rect key="frame" x="12" y="138" width="276" height="38"/>
+                                        <rect key="frame" x="12" y="134.5" width="276" height="52.5"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="15"/>
                                         <color key="textColor" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -607,7 +607,7 @@
                                 <edgeInsets key="layoutMargins" top="12" left="12" bottom="12" right="12"/>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="pgq-Uc-0I8">
-                                <rect key="frame" x="57" y="542" width="300" height="50"/>
+                                <rect key="frame" x="57" y="547.5" width="300" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6hW-GA-c9D">
                                         <rect key="frame" x="0.0" y="0.0" width="150" height="50"/>

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -79,6 +79,11 @@ class SendViewController: UIViewController {
             return false
         }
         
+        if sendAmountDcr > DcrlibwalletMaxAmountDcr {
+            self.sendAmountErrorLabel.text = "Amount more than maximum allowed."
+            return false
+        }
+        
         let sourceAccountBalance = self.walletAccounts[self.sourceAccountDropdown.selectedItemIndex].Balance!.dcrSpendable
         if sendAmountDcr > sourceAccountBalance {
             self.sendAmountErrorLabel.text = self.insufficientFundsErrorMessage
@@ -316,6 +321,14 @@ class SendViewController: UIViewController {
                     self.toggleSendButtonState(addressValid: false, amountValid: false)
                 }
                 return
+        }
+        
+        // Send amount must be less than or equal to max amount.
+        guard sendAmountDcr <= DcrlibwalletMaxAmountDcr else {
+            // clear tx summary and disable send button
+            self.clearTxSummary()
+            self.toggleSendButtonState(addressValid: false, amountValid: false)
+            return
         }
         
         guard let destinationAddress = self.getDestinationAddress(isSendAttempt: isSendAttempt) else {

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -206,6 +206,9 @@ class SendViewController: UIViewController {
             return "\(account.Name) [\(spendableBalance.round(8).formattedWithSeparator)]"
         })
         self.sourceAccountDropdown.initMenu(accountDropdownItems) { selectedAccountIndex, _ in
+            if self.sendMaxAmount {
+                self.calculateAndDisplayMaxSendableAmount()
+            }
             self.displayTransactionSummary()
         }
         self.destinationAccountDropdown.initMenu(accountDropdownItems)
@@ -242,6 +245,10 @@ class SendViewController: UIViewController {
     }
     
     @IBAction func sendMaxTap(_ sender: Any) {
+        self.calculateAndDisplayMaxSendableAmount()
+    }
+    
+    func calculateAndDisplayMaxSendableAmount() {
         let sourceAccount = self.walletAccounts[self.sourceAccountDropdown.selectedItemIndex]
         if sourceAccount.Balance?.Spendable == 0 {
             // nothing to send

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -109,9 +109,7 @@ class SendViewController: UIViewController {
         self.usdAmountTextField.text = ""
         self.sendAmountErrorLabel.text = ""
         
-        self.estimatedFeeLabel.text = "0.00 DCR"
-        self.estimatedTxSizeLabel.text = "0 bytes"
-        self.balanceAfterSendingLabel.text = "0.00 DCR"
+        self.clearTxSummary()
         
         self.sendErrorLabel.isHidden = true
         self.toggleSendButtonState(addressValid: false, amountValid: false)
@@ -302,11 +300,16 @@ class SendViewController: UIViewController {
     }
     
     func prepareTxSummary(isSendAttempt: Bool, completion: (Double, String, DcrlibwalletTxFeeAndSize) -> Void) {
-        guard let dcrAmountString = self.dcrAmountTextField.text, dcrAmountString != "" else {
-            if isSendAttempt {
-                self.sendAmountErrorLabel.text = "Amount cannot be zero."
-            }
-            return
+        guard let dcrAmountString = self.dcrAmountTextField.text, dcrAmountString != "",
+            let sendAmountDcr = Double(dcrAmountString), sendAmountDcr > 0 else {
+                self.clearTxSummary()
+                if isSendAttempt {
+                    self.sendAmountErrorLabel.text = "Amount cannot be zero."
+                } else {
+                    // disable send button
+                    self.toggleSendButtonState(addressValid: false, amountValid: false)
+                }
+                return
         }
         
         guard let destinationAddress = self.getDestinationAddress(isSendAttempt: isSendAttempt) else {
@@ -319,7 +322,6 @@ class SendViewController: UIViewController {
         }
         
         do {
-            let sendAmountDcr = Double(dcrAmountString)!
             let sendAmountAtom = DcrlibwalletAmountAtom(sendAmountDcr)
             let sourceAccountNumber = self.walletAccounts[self.sourceAccountDropdown.selectedItemIndex].Number
             

--- a/Decred Wallet/Features/Wallet Utils/Syncer.swift
+++ b/Decred Wallet/Features/Wallet Utils/Syncer.swift
@@ -88,7 +88,8 @@ class Syncer: NSObject, AppLifeCycleDelegate {
             self.currentSyncOp = nil
             self.currentSyncOpProgress = nil
             self.shouldRestartSync = true
-            AppDelegate.walletLoader.wallet?.cancelSync()
+            // Cancel ongoing sync without losing peers as we intend to restart the sync.
+            AppDelegate.walletLoader.wallet?.cancelSync(false)
         }
     }
     


### PR DESCRIPTION
Resolves #430 (send max occasionally producing "insufficient funds" error). Requires building with latest code on `dcrlibwallet/master`.

Send page code is also refactored/simplified by introducing new helper functions from dcrlibwallet:
- `CalculateNewTxFeeAndSize` called
  - when the send amount changes, to display the fee and tx size estimate on the send page; and
  - when the "Send" button is tapped, to display the fee on the send confirmation dialog.
- `EstimateMaxSendAmount` called when the "SEND MAX" button is tapped, to fetch maximum send amount for display in the amount field.