### PR TITLE
Implement delete wallet function

### DIFF
--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		B36255B622A11A9500C62946 /* SecurityMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36255B422A11A9500C62946 /* SecurityMenuViewController.swift */; };
 		B36255B722A11A9500C62946 /* SecurityMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B36255B522A11A9500C62946 /* SecurityMenu.storyboard */; };
 		B36EFD362298617C002753B2 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36EFD352298617C002753B2 /* UIButton.swift */; };
+		B377DB0722A5663700BDF56F /* DeleteWalletConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */; };
 		B39BDC4D228F798300F3FB55 /* BuildConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39BDC4C228F798300F3FB55 /* BuildConfig.swift */; };
 		B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF8522936BFE00008A4E /* Reachability.swift */; };
 		B3A3EF88229375D100008A4E /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF87229375D100008A4E /* Date.swift */; };
@@ -145,6 +146,7 @@
 		B36255B422A11A9500C62946 /* SecurityMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityMenuViewController.swift; sourceTree = "<group>"; };
 		B36255B522A11A9500C62946 /* SecurityMenu.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SecurityMenu.storyboard; sourceTree = "<group>"; };
 		B36EFD352298617C002753B2 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
+		B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteWalletConfirmationViewController.swift; sourceTree = "<group>"; };
 		B39BDC4C228F798300F3FB55 /* BuildConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfig.swift; sourceTree = "<group>"; };
 		B3A3EF8522936BFE00008A4E /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		B3A3EF87229375D100008A4E /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -687,6 +689,7 @@
 				B3B46A63228F0F7B00A68EDD /* ServerSetTableViewController.swift */,
 				B3B46A60228F0F7B00A68EDD /* CertificateViewController.swift */,
 				B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */,
+				B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -914,6 +917,7 @@
 				B3B46A26228F0F2700A68EDD /* CreateNewWalletViewController.swift in Sources */,
 				B3B46A14228F0F2700A68EDD /* AccountsHeaderView.swift in Sources */,
 				B3B46A1F228F0F2700A68EDD /* RequestPinViewController.swift in Sources */,
+				B377DB0722A5663700BDF56F /* DeleteWalletConfirmationViewController.swift in Sources */,
 				B3B469A6228F0F0700A68EDD /* AccountsData.swift in Sources */,
 				B3A3EF88229375D100008A4E /* Date.swift in Sources */,
 				B3B46A21228F0F2700A68EDD /* SecurityBaseViewController.swift in Sources */,

--- a/Decred Wallet/Base.lproj/Main.storyboard
+++ b/Decred Wallet/Base.lproj/Main.storyboard
@@ -339,9 +339,6 @@
                                     <constraint firstItem="c0d-2Z-wlh" firstAttribute="width" secondItem="Je2-ms-0XC" secondAttribute="width" id="wgw-0S-EcR"/>
                                     <constraint firstItem="c0d-2Z-wlh" firstAttribute="centerX" secondItem="Je2-ms-0XC" secondAttribute="centerX" id="xe4-FG-X11"/>
                                 </constraints>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="ZUl-m5-HFt" appends="YES" id="EvI-uL-ERk"/>
-                                </connections>
                             </view>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRj-cn-ZPx">
                                 <rect key="frame" x="158" y="350.5" width="59" height="20.5"/>
@@ -376,11 +373,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="abl-tj-8Do" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer numberOfTapsRequired="2" id="ZUl-m5-HFt">
-                    <connections>
-                        <action selector="animatedLogoTap:" destination="BLx-jo-l82" id="USm-5h-K0b"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-858.39999999999998" y="-53.523238380809602"/>
         </scene>

--- a/Decred Wallet/Features/App Launch/StartScreenViewController.swift
+++ b/Decred Wallet/Features/App Launch/StartScreenViewController.swift
@@ -51,14 +51,6 @@ class StartScreenViewController: UIViewController {
         }
     }
     
-    @IBAction func animatedLogoTap(_ sender: Any) {
-        timer?.invalidate()
-        self.startTimerWhenViewAppears = true
-        
-        let settingsVC = SettingsController.instantiate().wrapInNavigationcontroller()
-        self.present(settingsVC, animated: true, completion: nil)
-    }
-    
     func loadMainScreen() {
         if !AppDelegate.walletLoader.isWalletCreated {
             self.displayWalletSetupScreen()

--- a/Decred Wallet/Features/Settings/DeleteWalletConfirmationViewController.swift
+++ b/Decred Wallet/Features/Settings/DeleteWalletConfirmationViewController.swift
@@ -19,9 +19,6 @@ class DeleteWalletConfirmationViewController: UIViewController, UITextFieldDeleg
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.modalTransitionStyle = .crossDissolve
-        self.modalPresentationStyle = .overCurrentContext
-        
         let tap = UITapGestureRecognizer(target: self.view, action: #selector(self.view.endEditing(_:)))
         tap.cancelsTouchesInView = false
         self.view.addGestureRecognizer(tap)

--- a/Decred Wallet/Features/Settings/DeleteWalletConfirmationViewController.swift
+++ b/Decred Wallet/Features/Settings/DeleteWalletConfirmationViewController.swift
@@ -1,0 +1,73 @@
+//
+//  DeleteWalletConfirmationViewController.swift
+//  Decred Wallet
+//
+//  Created by Wisdom Arerosuoghene on 03/06/2019.
+//  Copyright © 2019 Decred. All rights reserved.
+//
+
+import UIKit
+
+class DeleteWalletConfirmationViewController: UIViewController, UITextFieldDelegate {
+    @IBOutlet weak var dialogBackground: UIView!
+    @IBOutlet weak var enterPasswordHint: UILabel!
+    @IBOutlet weak var passwordTextField: UITextField!
+    @IBOutlet weak var deleteButton: UIButton!
+    
+    var onDeleteWalletConfirmed: ((String?) -> Void)?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.modalTransitionStyle = .crossDissolve
+        self.modalPresentationStyle = .overCurrentContext
+        
+        let tap = UITapGestureRecognizer(target: self.view, action: #selector(self.view.endEditing(_:)))
+        tap.cancelsTouchesInView = false
+        self.view.addGestureRecognizer(tap)
+        
+        if SpendingPinOrPassword.currentSecurityType() == SecurityViewController.SECURITY_TYPE_PASSWORD {
+            self.passwordTextField.delegate = self
+            self.passwordTextField.addTarget(self, action: #selector(self.passwordTextChanged), for: .editingChanged)
+        } else {
+            self.enterPasswordHint.isHidden = true
+            self.passwordTextField.isHidden = true
+            self.deleteButton.isEnabled = true
+        }
+        
+        let layer = view.layer
+        layer.frame = self.dialogBackground.frame
+        layer.shadowColor = UIColor.gray.cgColor
+        layer.shadowRadius = 30
+        layer.shadowOpacity = 0.8
+        layer.shadowOffset = CGSize(width:0.0, height:40.0);
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if self.deleteButton.isEnabled {
+            self.deleteWalletConfirmed(self.deleteButton)
+        }
+        return self.deleteButton.isEnabled
+    }
+    
+    @objc func passwordTextChanged() {
+        guard let password = self.passwordTextField.text, password.count > 0 else {
+            self.deleteButton.isEnabled = false
+            return
+        }
+        self.deleteButton.isEnabled = true
+    }
+
+    @IBAction func deleteWalletConfirmed(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
+        if SpendingPinOrPassword.currentSecurityType() == SecurityViewController.SECURITY_TYPE_PASSWORD {
+            self.onDeleteWalletConfirmed?(self.passwordTextField.text!)
+        } else {
+            self.onDeleteWalletConfirmed?(nil)
+        }
+    }
+    
+    @IBAction func cancelDeleteWalletOperation(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
+    }
+}

--- a/Decred Wallet/Features/Settings/Settings.storyboard
+++ b/Decred Wallet/Features/Settings/Settings.storyboard
@@ -870,7 +870,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="ThS-ek-T27">
                                 <rect key="frame" x="37.5" y="194" width="300" height="229.5"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Delete Wallet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1ru-3D-ysZ">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Delete Wallet?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1ru-3D-ysZ">
                                         <rect key="frame" x="12" y="12" width="276" height="20.5"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                         <color key="textColor" red="0.2274509804" green="0.84313725490000002" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>

--- a/Decred Wallet/Features/Settings/Settings.storyboard
+++ b/Decred Wallet/Features/Settings/Settings.storyboard
@@ -447,7 +447,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="GYO-dh-yj3" kind="presentation" identifier="ShowDeleteWalletConfirmationDialog" id="YVG-mR-MqA"/>
+                                            <segue destination="GYO-dh-yj3" kind="presentation" identifier="ShowDeleteWalletConfirmationDialog" animates="NO" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" id="YVG-mR-MqA"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -864,11 +864,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lJv-DI-xo1">
-                                <rect key="frame" x="37.5" y="197.5" width="300" height="222.5"/>
+                                <rect key="frame" x="37.5" y="194" width="300" height="229.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ThS-ek-T27">
-                                <rect key="frame" x="37.5" y="197.5" width="300" height="222.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="ThS-ek-T27">
+                                <rect key="frame" x="37.5" y="194" width="300" height="229.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Delete Wallet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1ru-3D-ysZ">
                                         <rect key="frame" x="12" y="12" width="276" height="20.5"/>
@@ -877,27 +877,20 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wGN-Vb-4w1">
-                                        <rect key="frame" x="12" y="38.5" width="276" height="101"/>
+                                        <rect key="frame" x="12" y="44.5" width="276" height="101"/>
                                         <string key="text">Are you sure you want to delete your wallet? Make sure you have your wallet seed saved or your coins moved before deleting. This will also clear all app settings to a default state.</string>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
-                                        <color key="textColor" red="0.37254901959999998" green="0.44705882349999998" blue="0.52549019610000003" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jjY-6s-Zks">
-                                        <rect key="frame" x="12" y="145.5" width="276" height="5"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="5" id="Z6U-tA-han"/>
-                                        </constraints>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="To confirm, enter your password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="HeM-rT-uvn">
-                                        <rect key="frame" x="12" y="156.5" width="276" height="18"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="To confirm, enter your password:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="HeM-rT-uvn">
+                                        <rect key="frame" x="12" y="157.5" width="276" height="18"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
-                                        <color key="textColor" red="0.37254901959999998" green="0.44705882349999998" blue="0.52549019610000003" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H86-92-JuD">
-                                        <rect key="frame" x="12" y="180.5" width="276" height="30"/>
+                                        <rect key="frame" x="12" y="187.5" width="276" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
@@ -909,7 +902,7 @@
                                 <edgeInsets key="layoutMargins" top="12" left="12" bottom="12" right="12"/>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v6E-lM-qRz">
-                                <rect key="frame" x="37.5" y="420" width="300" height="50"/>
+                                <rect key="frame" x="37.5" y="423.5" width="300" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uOt-1V-xLA">
                                         <rect key="frame" x="0.0" y="10" width="150" height="30"/>
@@ -953,7 +946,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="ThS-ek-T27" firstAttribute="centerY" secondItem="Tcq-KN-erN" secondAttribute="centerY" constant="-25" id="1hI-mf-BvA"/>
                             <constraint firstItem="ThS-ek-T27" firstAttribute="centerX" secondItem="Tcq-KN-erN" secondAttribute="centerX" id="Eea-t7-Fmr"/>

--- a/Decred Wallet/Features/Settings/Settings.storyboard
+++ b/Decred Wallet/Features/Settings/Settings.storyboard
@@ -6,8 +6,17 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="SourceSansPro-Regular.ttf">
+            <string>SourceSansPro-Regular</string>
+        </array>
+        <array key="SourceSansPro-SemiBold.ttf">
+            <string>SourceSansPro-SemiBold</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--Settings Controller-->
         <scene sceneID="E8C-IB-Uk6">
@@ -329,7 +338,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pre-release" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5I-QX-JBY">
-                                                    <rect key="frame" x="293" y="8" width="113" height="27.5"/>
+                                                    <rect key="frame" x="254" y="8" width="113" height="27.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="113" id="m5i-SU-Vpj"/>
                                                     </constraints>
@@ -356,7 +365,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMj-Ry-6VY">
-                                                    <rect key="frame" x="230" y="16.5" width="176" height="20"/>
+                                                    <rect key="frame" x="191" y="16.5" width="176" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="176" id="z30-iK-TqZ"/>
                                                     </constraints>
@@ -392,7 +401,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Rescan Blockchain" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eOS-CJ-QEb">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -405,11 +414,11 @@
                                         <rect key="frame" x="0.0" y="839.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="P3v-pp-Ab2" id="lrZ-sQ-5Tp">
-                                            <rect key="frame" x="0.0" y="0.0" width="349" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Wallet Log" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="roe-vF-JdQ">
-                                                    <rect key="frame" x="15" y="0.0" width="325" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -419,6 +428,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="YSv-gj-0dD" kind="show" id="891-c5-g6R"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="delete_wallet_settings" textLabel="dgz-JW-F6y" style="IBUITableViewCellStyleDefault" id="JNZ-nH-m85">
+                                        <rect key="frame" x="0.0" y="883.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JNZ-nH-m85" id="ug0-e8-luS">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Delete Wallet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dgz-JW-F6y">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="GYO-dh-yj3" kind="presentation" identifier="ShowDeleteWalletConfirmationDialog" id="YVG-mR-MqA"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -455,33 +484,6 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9zL-3t-ck0" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="JjF-Qe-zu4"/>
-                <tableViewCell hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="cGS-0D-Yw9">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cGS-0D-Yw9" id="NPL-q7-hGx">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8yy-Hu-jNf">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <inset key="titleEdgeInsets" minX="20" minY="10" maxX="0.0" maxY="0.0"/>
-                                <state key="normal" title="Delete Wallet">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <connections>
-                                    <action selector="deleteWallet:" destination="D9F-Sd-24p" eventType="touchUpInside" id="4tp-cf-fLu"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="8yy-Hu-jNf" firstAttribute="centerY" secondItem="NPL-q7-hGx" secondAttribute="centerY" id="TKr-Lp-lV0"/>
-                            <constraint firstItem="8yy-Hu-jNf" firstAttribute="centerX" secondItem="NPL-q7-hGx" secondAttribute="centerX" id="c2o-rq-3qS"/>
-                            <constraint firstItem="8yy-Hu-jNf" firstAttribute="height" secondItem="NPL-q7-hGx" secondAttribute="height" id="hXO-qk-3hN"/>
-                            <constraint firstItem="8yy-Hu-jNf" firstAttribute="width" secondItem="NPL-q7-hGx" secondAttribute="width" id="t2O-Sf-lmX"/>
-                        </constraints>
-                    </tableViewCellContentView>
-                </tableViewCell>
             </objects>
             <point key="canvasLocation" x="13.6" y="2149.4752623688159"/>
         </scene>
@@ -713,7 +715,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Bgv-pB-2R0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="14" y="2917"/>
+            <point key="canvasLocation" x="2276" y="3263"/>
         </scene>
         <!--Peer Set Table View Controller-->
         <scene sceneID="CDq-Z7-nHX">
@@ -848,6 +850,133 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="95M-MY-Fee" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1174" y="1718"/>
+        </scene>
+        <!--Delete Wallet Confirmation View Controller-->
+        <scene sceneID="ftG-bP-LXN">
+            <objects>
+                <viewController storyboardIdentifier="ConfirmToSendFundViewController" id="GYO-dh-yj3" customClass="DeleteWalletConfirmationViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Y91-i3-wnW"/>
+                        <viewControllerLayoutGuide type="bottom" id="Fg2-BG-twn"/>
+                    </layoutGuides>
+                    <view key="view" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" id="Tcq-KN-erN">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lJv-DI-xo1">
+                                <rect key="frame" x="37.5" y="197.5" width="300" height="222.5"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ThS-ek-T27">
+                                <rect key="frame" x="37.5" y="197.5" width="300" height="222.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Delete Wallet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1ru-3D-ysZ">
+                                        <rect key="frame" x="12" y="12" width="276" height="20.5"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                        <color key="textColor" red="0.2274509804" green="0.84313725490000002" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wGN-Vb-4w1">
+                                        <rect key="frame" x="12" y="38.5" width="276" height="101"/>
+                                        <string key="text">Are you sure you want to delete your wallet? Make sure you have your wallet seed saved or your coins moved before deleting. This will also clear all app settings to a default state.</string>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                        <color key="textColor" red="0.37254901959999998" green="0.44705882349999998" blue="0.52549019610000003" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jjY-6s-Zks">
+                                        <rect key="frame" x="12" y="145.5" width="276" height="5"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="5" id="Z6U-tA-han"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="To confirm, enter your password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="HeM-rT-uvn">
+                                        <rect key="frame" x="12" y="156.5" width="276" height="18"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
+                                        <color key="textColor" red="0.37254901959999998" green="0.44705882349999998" blue="0.52549019610000003" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H86-92-JuD">
+                                        <rect key="frame" x="12" y="180.5" width="276" height="30"/>
+                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="300" id="QVq-oL-zY1"/>
+                                </constraints>
+                                <edgeInsets key="layoutMargins" top="12" left="12" bottom="12" right="12"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v6E-lM-qRz">
+                                <rect key="frame" x="37.5" y="420" width="300" height="50"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uOt-1V-xLA">
+                                        <rect key="frame" x="0.0" y="10" width="150" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="yY0-zF-W0F"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                        <state key="normal" title="NO">
+                                            <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="cancelDeleteWalletOperation:" destination="GYO-dh-yj3" eventType="touchUpInside" id="p89-XS-IVy"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gJ7-H4-7Se">
+                                        <rect key="frame" x="150" y="10" width="150" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="s5t-KS-l46"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                        <state key="normal" title="DELETE">
+                                            <color key="titleColor" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                        <state key="disabled">
+                                            <color key="titleColor" red="0.83921568629999999" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="deleteWalletConfirmed:" destination="GYO-dh-yj3" eventType="touchUpInside" id="Gxx-y7-bzN"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" red="0.95294117649999999" green="0.96078431369999995" blue="0.96470588239999999" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstItem="uOt-1V-xLA" firstAttribute="leading" secondItem="v6E-lM-qRz" secondAttribute="leading" id="HXO-u1-ZQe"/>
+                                    <constraint firstItem="uOt-1V-xLA" firstAttribute="width" secondItem="v6E-lM-qRz" secondAttribute="width" multiplier="0.5" id="UpU-CD-egD"/>
+                                    <constraint firstAttribute="height" constant="50" id="bHi-0J-egd"/>
+                                    <constraint firstItem="uOt-1V-xLA" firstAttribute="centerY" secondItem="v6E-lM-qRz" secondAttribute="centerY" id="dnT-di-fSM"/>
+                                    <constraint firstItem="gJ7-H4-7Se" firstAttribute="width" secondItem="v6E-lM-qRz" secondAttribute="width" multiplier="0.5" id="dsB-ld-jXQ"/>
+                                    <constraint firstItem="gJ7-H4-7Se" firstAttribute="centerY" secondItem="v6E-lM-qRz" secondAttribute="centerY" id="lTB-RV-6Jn"/>
+                                    <constraint firstAttribute="trailing" secondItem="gJ7-H4-7Se" secondAttribute="trailing" id="pTU-Lu-bt6"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="ThS-ek-T27" firstAttribute="centerY" secondItem="Tcq-KN-erN" secondAttribute="centerY" constant="-25" id="1hI-mf-BvA"/>
+                            <constraint firstItem="ThS-ek-T27" firstAttribute="centerX" secondItem="Tcq-KN-erN" secondAttribute="centerX" id="Eea-t7-Fmr"/>
+                            <constraint firstItem="lJv-DI-xo1" firstAttribute="top" secondItem="ThS-ek-T27" secondAttribute="top" id="FCG-B8-AnZ"/>
+                            <constraint firstItem="v6E-lM-qRz" firstAttribute="trailing" secondItem="ThS-ek-T27" secondAttribute="trailing" id="GQN-WW-hui"/>
+                            <constraint firstItem="lJv-DI-xo1" firstAttribute="width" secondItem="ThS-ek-T27" secondAttribute="width" id="RTX-Re-QFJ"/>
+                            <constraint firstItem="lJv-DI-xo1" firstAttribute="height" secondItem="ThS-ek-T27" secondAttribute="height" id="cYv-qP-lbg"/>
+                            <constraint firstItem="lJv-DI-xo1" firstAttribute="leading" secondItem="ThS-ek-T27" secondAttribute="leading" id="dNy-zn-Ksp"/>
+                            <constraint firstItem="v6E-lM-qRz" firstAttribute="leading" secondItem="ThS-ek-T27" secondAttribute="leading" id="k5o-SJ-mW7"/>
+                            <constraint firstItem="v6E-lM-qRz" firstAttribute="top" secondItem="ThS-ek-T27" secondAttribute="bottom" id="u3S-RW-Vdb"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="eQt-7u-f47"/>
+                    </view>
+                    <connections>
+                        <outlet property="deleteButton" destination="gJ7-H4-7Se" id="anp-HS-8IV"/>
+                        <outlet property="dialogBackground" destination="lJv-DI-xo1" id="gWt-Tp-uCd"/>
+                        <outlet property="enterPasswordHint" destination="HeM-rT-uvn" id="xui-aj-bLz"/>
+                        <outlet property="passwordTextField" destination="H86-92-JuD" id="JcK-GI-4DB"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4oM-GD-CEU" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1174" y="3262"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
Resolves #385.
Also removes the double tap action on splash screen logo that shows the settings page to prevent access to the settings page before a wallet is loaded.

Requires https://github.com/raedahgroup/dcrlibwallet/pull/32

<img width="300" alt="Screenshot 2019-06-03 at 8 35 39 PM" src="https://user-images.githubusercontent.com/18400051/58829405-a2913e00-863f-11e9-9715-ecf35f29a2df.png">
