### PR TITLE
Restore double tap splash screen logo to show settings. Prevent settings crash if wallet is not opened.

### DIFF
--- a/Decred Wallet/Base.lproj/Main.storyboard
+++ b/Decred Wallet/Base.lproj/Main.storyboard
@@ -328,6 +328,10 @@
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="c0d-2Z-wlh">
                                         <rect key="frame" x="0.0" y="0.0" width="140" height="105"/>
+                                        <gestureRecognizers/>
+                                        <connections>
+                                            <outletCollection property="gestureRecognizers" destination="hk2-L0-l0m" appends="YES" id="j8f-h5-kvi"/>
+                                        </connections>
                                     </imageView>
                                 </subviews>
                                 <gestureRecognizers/>
@@ -373,6 +377,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="abl-tj-8Do" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer numberOfTapsRequired="2" id="hk2-L0-l0m">
+                    <connections>
+                        <action selector="animatedLogoTap:" destination="BLx-jo-l82" id="243-wN-MKT"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-858.39999999999998" y="-53.523238380809602"/>
         </scene>

--- a/Decred Wallet/Base.lproj/Main.storyboard
+++ b/Decred Wallet/Base.lproj/Main.storyboard
@@ -329,9 +329,6 @@
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="c0d-2Z-wlh">
                                         <rect key="frame" x="0.0" y="0.0" width="140" height="105"/>
                                         <gestureRecognizers/>
-                                        <connections>
-                                            <outletCollection property="gestureRecognizers" destination="hk2-L0-l0m" appends="YES" id="j8f-h5-kvi"/>
-                                        </connections>
                                     </imageView>
                                 </subviews>
                                 <gestureRecognizers/>
@@ -343,6 +340,9 @@
                                     <constraint firstItem="c0d-2Z-wlh" firstAttribute="width" secondItem="Je2-ms-0XC" secondAttribute="width" id="wgw-0S-EcR"/>
                                     <constraint firstItem="c0d-2Z-wlh" firstAttribute="centerX" secondItem="Je2-ms-0XC" secondAttribute="centerX" id="xe4-FG-X11"/>
                                 </constraints>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="hk2-L0-l0m" appends="YES" id="oUV-kK-Hs0"/>
+                                </connections>
                             </view>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="testnet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRj-cn-ZPx">
                                 <rect key="frame" x="158" y="350.5" width="59" height="20.5"/>

--- a/Decred Wallet/Features/App Launch/StartScreenViewController.swift
+++ b/Decred Wallet/Features/App Launch/StartScreenViewController.swift
@@ -40,7 +40,7 @@ class StartScreenViewController: UIViewController {
         
         // start timer to load main screen after specified interval
         if self.startTimerWhenViewAppears {
-            timer = Timer.scheduledTimer(withTimeInterval: self.animationDurationSeconds, repeats: false) {_ in
+            self.timer = Timer.scheduledTimer(withTimeInterval: self.animationDurationSeconds, repeats: false) {_ in
                 self.loadMainScreen()
             }
             self.startTimerWhenViewAppears = false
@@ -49,6 +49,14 @@ class StartScreenViewController: UIViewController {
         if AppDelegate.walletLoader.isWalletCreated {
             self.label.text = "Opening wallet..."
         }
+    }
+    
+    @IBAction func animatedLogoTap(_ sender: Any) {
+        self.timer?.invalidate()
+        self.startTimerWhenViewAppears = true
+        
+        let settingsVC = SettingsController.instantiate().wrapInNavigationcontroller()
+        self.present(settingsVC, animated: true, completion: nil)
     }
     
     func loadMainScreen() {

--- a/Decred Wallet/Features/Settings/Settings.storyboard
+++ b/Decred Wallet/Features/Settings/Settings.storyboard
@@ -401,7 +401,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Rescan Blockchain" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eOS-CJ-QEb">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -414,11 +414,11 @@
                                         <rect key="frame" x="0.0" y="839.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="P3v-pp-Ab2" id="lrZ-sQ-5Tp">
-                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Wallet Log" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="roe-vF-JdQ">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="325" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -438,7 +438,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Delete Wallet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dgz-JW-F6y">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>


### PR DESCRIPTION
Resolves #443.
Settings options requiring a wallet are hidden if the settings page is opened before the wallet is opened (or created).