### PR TITLE
PIN setup view: show as many dots as possible before switching to text

### DIFF
--- a/Decred Wallet/Features/Security/PinInputView.swift
+++ b/Decred Wallet/Features/Security/PinInputView.swift
@@ -11,7 +11,7 @@ import UIKit
 class PinInputView: UIView {
     static let spacingBetweenPinCircles: CGFloat = 10.0
     static let circleBorderSizeFactor: CGFloat = 0.15
-    static let maxNumberOfPinCircles = 5
+    static let defaultCircleDiameter: CGFloat = 30.0
     
     var maxNumberOfDigits: Int = Int(LONG_MAX)
     
@@ -20,6 +20,17 @@ class PinInputView: UIView {
             self.subviews.forEach{ $0.removeFromSuperview() }
             self.setNeedsDisplay()
         }
+    }
+    
+    var pinCircleDiameter: CGFloat {
+        let eachCircleDiameter = self.frame.height * 0.8
+        return eachCircleDiameter > PinInputView.defaultCircleDiameter ? PinInputView.defaultCircleDiameter : eachCircleDiameter
+    }
+    
+    var totalWidthRequiredToDisplayAllPinCircles: CGFloat {
+        let totalPinCircleWidths = CGFloat(self.pin.count) * self.pinCircleDiameter
+        let totalSpaceBetweenPins = CGFloat(self.pin.count - 1) * PinInputView.spacingBetweenPinCircles
+        return totalPinCircleWidths + totalSpaceBetweenPins
     }
     
     func append(digit: Int) -> String {
@@ -44,7 +55,7 @@ class PinInputView: UIView {
     }
     
     func drawCells(in frame: CGRect) {
-        if pin.count > PinInputView.maxNumberOfPinCircles {
+        if self.totalWidthRequiredToDisplayAllPinCircles > frame.width {
             self.drawPinLabel(in: frame)
         } else {
             self.drawPinCircles(in: frame)
@@ -64,18 +75,10 @@ class PinInputView: UIView {
     }
     
     func drawPinCircles(in frame: CGRect) {
-        let maxWidthPerCircle = frame.width / CGFloat(PinInputView.maxNumberOfPinCircles)
-        
-        var eachCircleDiameter = frame.height * 0.8
-        if eachCircleDiameter > maxWidthPerCircle {
-            eachCircleDiameter = maxWidthPerCircle
-        }
+        let eachCircleDiameter = self.pinCircleDiameter
         
         // calculate x pos for first pin circle
-        let totalPinCircleWidths = CGFloat(self.pin.count) * eachCircleDiameter
-        let totalSpaceBetweenPins = CGFloat(self.pin.count - 1) * PinInputView.spacingBetweenPinCircles
-        let totalPinCircleWidthPlusSpacing = totalPinCircleWidths + totalSpaceBetweenPins
-        var nextXPos = (frame.width - totalPinCircleWidthPlusSpacing) / 2
+        var nextXPos = (frame.width - self.totalWidthRequiredToDisplayAllPinCircles) / 2
         
         for _ in 0..<pin.count {
             self.drawPinCircle(in: frame, xPos: nextXPos, diameter: eachCircleDiameter)

--- a/Decred Wallet/Features/Security/Security.storyboard
+++ b/Decred Wallet/Features/Security/Security.storyboard
@@ -264,10 +264,9 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4YA-nq-sBC" customClass="PinInputView" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="107" y="114.5" width="200" height="30"/>
+                                <rect key="frame" x="20.5" y="114.5" width="373" height="30"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="Obr-AI-6yX"/>
                                     <constraint firstAttribute="height" constant="30" id="tTh-ef-kAt"/>
                                 </constraints>
                             </view>
@@ -576,6 +575,7 @@
                             <constraint firstItem="1CY-jq-OSD" firstAttribute="centerX" secondItem="MZP-zs-4TF" secondAttribute="centerX" id="WKm-0f-0Jb"/>
                             <constraint firstItem="aau-sy-kMa" firstAttribute="top" secondItem="rJT-9u-LTj" secondAttribute="bottom" constant="6" id="gJ0-6h-YEL"/>
                             <constraint firstItem="CY7-XY-0kP" firstAttribute="leading" secondItem="hEG-La-4vV" secondAttribute="leading" constant="18" id="m4z-Wu-q6n"/>
+                            <constraint firstItem="4YA-nq-sBC" firstAttribute="width" secondItem="MZP-zs-4TF" secondAttribute="width" multiplier="0.9" id="wPN-Nu-cqq"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="hEG-La-4vV"/>
                     </view>


### PR DESCRIPTION
Resolves #449.

<img width="300" alt="Screenshot 2019-06-06 at 9 07 14 PM" src="https://user-images.githubusercontent.com/18400051/59063250-97d4e400-889f-11e9-82f3-52eb8f81a615.png">
<img width="300" alt="Screenshot 2019-06-06 at 9 07 17 PM" src="https://user-images.githubusercontent.com/18400051/59063251-97d4e400-889f-11e9-8b02-1fe9a443c16b.png">

<img width="400" alt="Screenshot 2019-06-06 at 9 09 22 PM" src="https://user-images.githubusercontent.com/18400051/59063252-986d7a80-889f-11e9-8564-ae83a3475845.png">
<img width="400" alt="Screenshot 2019-06-06 at 9 09 24 PM" src="https://user-images.githubusercontent.com/18400051/59063255-986d7a80-889f-11e9-87ec-d4014d017c00.png">
