### PR TITLE
Correct app display names for testnet and mainnet build variants

### DIFF
--- a/Decred Wallet/Info.plist
+++ b/Decred Wallet/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Decred Wallet</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Both testnet and mainnet builds currently show "Decred Wallet" as app name. This was mistakenly introduced in https://github.com/raedahgroup/dcrios/commit/a2aa125d3ef0d3cc64a015684caf2e6221223162#diff-8ce76d30139bfa654785f8300d8f229dR8.