### PR TITLE
Overview, history pages: blink for new transactions

### DIFF
--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -69,4 +69,39 @@ extension DcrlibwalletLibWallet {
     func totalWalletBalance(confirmations: Int32 = 0) -> Double {
         return self.walletAccounts(confirmations: confirmations).filter({ !$0.isHidden }).map({ $0.dcrTotalBalance }).reduce(0,+)
     }
+    
+    func transactionHistory(count: Int32, completion: @escaping ([Transaction]?) -> Void) {
+        DispatchQueue.global(qos: .userInteractive).async {
+            do {
+                var getTransactionsError: NSError?
+                let transactionsJson = AppDelegate.walletLoader.wallet?.getTransactions(count, error: &getTransactionsError)
+                if getTransactionsError != nil {
+                    throw getTransactionsError!
+                }
+                var transactions = try JSONDecoder().decode([Transaction].self, from: transactionsJson!.utf8Bits)
+                
+                // Check if there are new transactions since last time wallet history was displayed.
+                let lastTxHash = Settings.readOptionalValue(for: Settings.Keys.LastTxHash) ?? ""
+                for i in 0..<transactions.count {
+                    if transactions[i].Hash == lastTxHash {
+                        // We've hit the last viewed tx. No need to animate this tx or futher txs.
+                        break
+                    }
+                    transactions[i].Animate = true
+                }
+                
+                // Save hash for tx index 0 as last viewed tx hash.
+                Settings.setValue(transactions[0].Hash, for: Settings.Keys.LastTxHash)
+                
+                DispatchQueue.main.async {
+                    completion(transactions)
+                }
+            } catch let error {
+                print("tx history error: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+            }
+        }
+    }
 }

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -150,8 +150,10 @@ extension OverviewViewController: NewTransactionNotificationProtocol, ConfirmedT
     }
     
     func onTransactionConfirmed(_ hash: String?, height: Int32) {
-        self.updateCurrentBalance()
-        self.loadRecentActivity()
+        DispatchQueue.main.async {
+            self.updateCurrentBalance()
+            self.loadRecentActivity()
+        }
     }
 }
 

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -85,32 +85,26 @@ class OverviewViewController: UIViewController {
     }
     
     func loadRecentActivity() {
-        DispatchQueue.main.async {
-            do {
-                var getTransactionsError: NSError?
-                let maxDisplayItems = round(self.recentActivityTableView.frame.size.height / TransactionTableViewCell.height())
-                let transactionsJson = AppDelegate.walletLoader.wallet?.getTransactions(Int32(maxDisplayItems), error: &getTransactionsError)
-                if getTransactionsError != nil {
-                    throw getTransactionsError!
-                }
-                
-                self.recentTransactions = try JSONDecoder().decode([Transaction].self, from: transactionsJson!.utf8Bits)
-                
-                if self.recentTransactions.count > 0 {
-                    self.recentActivityTableView.backgroundView = nil
-                    self.recentActivityTableView.separatorStyle = .singleLine
-                    self.recentActivityTableView.reloadData()
-                } else {
-                    let label = UILabel(frame: CGRect(x: 0, y: 0, width: self.recentActivityTableView.bounds.size.width, height: self.recentActivityTableView.bounds.size.height))
-                    label.text = "No Transactions"
-                    label.textAlignment = .center
-                    self.recentActivityTableView.backgroundView = label
-                    self.recentActivityTableView.separatorStyle = .none
-                }
-            } catch let Error {
-                print(Error)
+        let maxDisplayItems = round(self.recentActivityTableView.frame.size.height / TransactionTableViewCell.height())
+        AppDelegate.walletLoader.wallet?.transactionHistory(count: Int32(maxDisplayItems)) { transactions in
+            if transactions == nil || transactions!.count == 0 {
+                self.showNoTransactions()
+                return
             }
+            
+            self.recentTransactions = transactions!
+            self.recentActivityTableView.backgroundView = nil
+            self.recentActivityTableView.separatorStyle = .singleLine
+            self.recentActivityTableView.reloadData()
         }
+    }
+    
+    func showNoTransactions() {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: self.recentActivityTableView.bounds.size.width, height: self.recentActivityTableView.bounds.size.height))
+        label.text = "No Transactions"
+        label.textAlignment = .center
+        self.recentActivityTableView.backgroundView = label
+        self.recentActivityTableView.separatorStyle = .none
     }
     
     @IBAction func showAllTransactionsButtonTap(_ sender: Any) {
@@ -141,6 +135,7 @@ extension OverviewViewController: NewTransactionNotificationProtocol, ConfirmedT
             return
         }
         
+        tx.Animate = true
         self.recentTransactions.insert(tx, at: 0)
         self.updateCurrentBalance()
         
@@ -150,7 +145,6 @@ extension OverviewViewController: NewTransactionNotificationProtocol, ConfirmedT
                 _ = self.recentTransactions.popLast()
             }
             
-            tx.Animate = true
             self.recentActivityTableView.reloadData()
         }
     }
@@ -175,6 +169,13 @@ extension OverviewViewController: UITableViewDelegate {
         txDetailsVC.transaction = self.recentTransactions[indexPath.row]
         self.navigationController?.pushViewController(txDetailsVC, animated: true)
     }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if self.recentTransactions[indexPath.row].Animate {
+            cell.blink()
+        }
+        self.recentTransactions[indexPath.row].Animate = false
+    }
 }
 
 extension OverviewViewController: UITableViewDataSource {
@@ -191,14 +192,5 @@ extension OverviewViewController: UITableViewDataSource {
         }
         
         return cell
-    }
-    
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if self.recentTransactions.count > indexPath.row {
-            if self.recentTransactions[indexPath.row].Animate {
-                cell.blink()
-            }
-            self.recentTransactions[indexPath.row].Animate = false
-        }
     }
 }

--- a/Decred Wallet/Utils/Settings.swift
+++ b/Decred Wallet/Utils/Settings.swift
@@ -21,6 +21,8 @@ class Settings {
         static let SpendUnconfirmed = "pref_spend_unconfirmed"
         static let CurrencyConversionOption = "currency_conversion_option"
         static let NetworkMode = "network_mode"
+        
+        static let LastTxHash = "last_tx_hash"
     }
     
     static func readValue<T>(for key: String) -> T {


### PR DESCRIPTION
Resolves #380.
- Implements incoming tx and new block notification listener on history page.
- Blinks when new transactions are displayed on overview or history page, including transactions that occurred while the app was closed.