### PR TITLE
security page: restyle tab for pass/pin

### DIFF
--- a/Decred Wallet/Extensions/UIButton.swift
+++ b/Decred Wallet/Extensions/UIButton.swift
@@ -53,22 +53,16 @@ extension UIButton {
             self.setNeedsLayout()
         }
     }
-
-    private func imageWithColor(color: UIColor) -> UIImage? {
-        let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
-        UIGraphicsBeginImageContext(rect.size)
-        let context = UIGraphicsGetCurrentContext()
-        
-        context?.setFillColor(color.cgColor)
-        context?.fill(rect)
-        
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return image
-    }
     
     func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
-        self.setBackgroundImage(imageWithColor(color: color), for: state)
+        self.clipsToBounds = true  // add this to maintain corner radius
+        UIGraphicsBeginImageContext(CGSize(width: 1, height: 1))
+        if let context = UIGraphicsGetCurrentContext() {
+            context.setFillColor(color.cgColor)
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+            let colorImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            self.setBackgroundImage(colorImage, for: state)
+        }
     }
 }

--- a/Decred Wallet/Extensions/UIButton.swift
+++ b/Decred Wallet/Extensions/UIButton.swift
@@ -16,7 +16,6 @@ extension UIButton {
         case bottom
     }
     
-    
     func addBorders(atPositions borderPositions: [BorderPosition], colorHex: String = "#4e5f70", thickness: CGFloat = 1.7) {
         borderPositions.forEach({ borderPosition in
             self.addBorder(atPosition: borderPosition, colorHex: colorHex, thickness: thickness)

--- a/Decred Wallet/Extensions/UIButton.swift
+++ b/Decred Wallet/Extensions/UIButton.swift
@@ -53,4 +53,22 @@ extension UIButton {
             self.setNeedsLayout()
         }
     }
+
+    private func imageWithColor(color: UIColor) -> UIImage? {
+        let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()
+        
+        context?.setFillColor(color.cgColor)
+        context?.fill(rect)
+        
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return image
+    }
+    
+    func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
+        self.setBackgroundImage(imageWithColor(color: color), for: state)
+    }
 }

--- a/Decred Wallet/Extensions/UIButton.swift
+++ b/Decred Wallet/Extensions/UIButton.swift
@@ -16,15 +16,15 @@ extension UIButton {
         case bottom
     }
     
-    func addBorders(atPositions borderPositions: [BorderPosition], colorHex: String = "#4e5f70", thickness: CGFloat = 1.7) {
+    func addBorders(atPositions borderPositions: [BorderPosition], color: UIColor = UIColor.appColors.darkGray, thickness: CGFloat = 1.7) {
         borderPositions.forEach({ borderPosition in
-            self.addBorder(atPosition: borderPosition, colorHex: colorHex, thickness: thickness)
+            self.addBorder(atPosition: borderPosition, color: color, thickness: thickness)
         })
     }
     
-    func addBorder(atPosition borderPosition: BorderPosition, colorHex: String = "#4e5f70", thickness: CGFloat = 1.7) {
+    func addBorder(atPosition borderPosition: BorderPosition, color: UIColor = UIColor.appColors.darkGray, thickness: CGFloat = 1.7) {
         let borderLayer = CALayer()
-        borderLayer.backgroundColor = UIColor.init(hex: colorHex).cgColor
+        borderLayer.backgroundColor = color.cgColor
         borderLayer.name = "\(borderPosition.rawValue) border"
         
         switch borderPosition {

--- a/Decred Wallet/Extensions/UIButton.swift
+++ b/Decred Wallet/Extensions/UIButton.swift
@@ -17,13 +17,13 @@ extension UIButton {
     }
     
     
-    func addBorders(atPositions borderPositions: [BorderPosition], colorHex: String = "#333333", thickness: CGFloat = 1.7) {
+    func addBorders(atPositions borderPositions: [BorderPosition], colorHex: String = "#4e5f70", thickness: CGFloat = 1.7) {
         borderPositions.forEach({ borderPosition in
             self.addBorder(atPosition: borderPosition, colorHex: colorHex, thickness: thickness)
         })
     }
     
-    func addBorder(atPosition borderPosition: BorderPosition, colorHex: String = "#333333", thickness: CGFloat = 1.7) {
+    func addBorder(atPosition borderPosition: BorderPosition, colorHex: String = "#4e5f70", thickness: CGFloat = 1.7) {
         let borderLayer = CALayer()
         borderLayer.backgroundColor = UIColor.init(hex: colorHex).cgColor
         borderLayer.name = "\(borderPosition.rawValue) border"

--- a/Decred Wallet/Extensions/UIColor.swift
+++ b/Decred Wallet/Extensions/UIColor.swift
@@ -25,6 +25,7 @@ extension UIColor {
         static let yellowWarning = UIColor.init(hex: "#FFC84E")
         static let tabActive = UIColor.init(hex: "#4e5f70")
         static let tabInActive = UIColor.init(hex: "#a4abb1")
+        static let highlightActive = UIColor.init(hex: "#a4abb1", alpha: 0.3)
     }
     
     convenience init(hex: String) {

--- a/Decred Wallet/Extensions/UIColor.swift
+++ b/Decred Wallet/Extensions/UIColor.swift
@@ -23,9 +23,9 @@ extension UIColor {
         static let offWhite = UIColor(hex:"#F3F5F6")
         static let lightOffWhite = UIColor(hex: "#F9FBFA")
         static let yellowWarning = UIColor.init(hex: "#FFC84E")
-        static let tabActive = UIColor.init(hex: "#4e5f70")
-        static let tabInactive = UIColor.init(hex: "#a4abb1")
-        static let lightTabInactive = UIColor.init(hex: "#a4abb1", alpha: 0.3)
+        static let thinGray = UIColor.init(hex: "#a4abb1")
+        static let darkGray = UIColor.init(hex: "#4e5f70")
+        static let transparentThinGray = UIColor.init(hex: "#a4abb1", alpha: 0.3)
     }
     
     convenience init(hex: String) {

--- a/Decred Wallet/Extensions/UIColor.swift
+++ b/Decred Wallet/Extensions/UIColor.swift
@@ -24,8 +24,8 @@ extension UIColor {
         static let lightOffWhite = UIColor(hex: "#F9FBFA")
         static let yellowWarning = UIColor.init(hex: "#FFC84E")
         static let tabActive = UIColor.init(hex: "#4e5f70")
-        static let tabInActive = UIColor.init(hex: "#a4abb1")
-        static let highlightActive = UIColor.init(hex: "#a4abb1", alpha: 0.3)
+        static let tabInactive = UIColor.init(hex: "#a4abb1")
+        static let lightTabInactive = UIColor.init(hex: "#a4abb1", alpha: 0.3)
     }
     
     convenience init(hex: String) {

--- a/Decred Wallet/Extensions/UIColor.swift
+++ b/Decred Wallet/Extensions/UIColor.swift
@@ -23,6 +23,8 @@ extension UIColor {
         static let offWhite = UIColor(hex:"#F3F5F6")
         static let lightOffWhite = UIColor(hex: "#F9FBFA")
         static let yellowWarning = UIColor.init(hex: "#FFC84E")
+        static let tabActive = UIColor.init(hex: "#4e5f70")
+        static let tabInActive = UIColor.init(hex: "#a4abb1")
     }
     
     convenience init(hex: String) {

--- a/Decred Wallet/Features/Security/Security.storyboard
+++ b/Decred Wallet/Features/Security/Security.storyboard
@@ -32,9 +32,10 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="pw2-ld-DVo">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="40"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FZP-4b-65P">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FZP-4b-65P">
                                                 <rect key="frame" x="0.0" y="0.0" width="207" height="40"/>
                                                 <color key="backgroundColor" red="0.95294117649999999" green="0.96078431369999995" blue="0.96470588239999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <state key="normal" title="PASSWORD">
                                                     <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 </state>
@@ -42,9 +43,10 @@
                                                     <action selector="onPasswordTab:" destination="oDz-Lc-3bI" eventType="touchUpInside" id="Djs-C0-rE0"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b4m-te-ci6">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b4m-te-ci6">
                                                 <rect key="frame" x="207" y="0.0" width="207" height="40"/>
                                                 <color key="backgroundColor" red="0.95294117647058818" green="0.96078431372549022" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <state key="normal" title="PIN">
                                                     <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 </state>
@@ -112,13 +114,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Security Password" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c3o-om-jRL">
-                                <rect key="frame" x="91" y="74" width="232" height="23.5"/>
+                                <rect key="frame" x="101.5" y="74" width="211" height="25.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                 <color key="textColor" red="0.039215686270000001" green="0.08235294118" blue="0.2470588235" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PASSWORD" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3VC-gV-ewC">
-                                <rect key="frame" x="165.5" y="117.5" width="83" height="21"/>
+                                <rect key="frame" x="165.5" y="119.5" width="83" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="Km3-3m-m17"/>
                                 </constraints>
@@ -127,7 +129,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zDA-08-WIe">
-                                <rect key="frame" x="107" y="152.5" width="200" height="25"/>
+                                <rect key="frame" x="107" y="154.5" width="200" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Iem-g2-gKG"/>
                                     <constraint firstAttribute="height" constant="25" id="Jlf-hF-RSv"/>
@@ -137,20 +139,20 @@
                                 <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oBs-BE-f5z">
-                                <rect key="frame" x="107" y="177.5" width="200" height="2"/>
+                                <rect key="frame" x="107" y="179.5" width="200" height="2"/>
                                 <color key="backgroundColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="Q4g-4g-dZ0"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONFIRM PASSWORD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lAl-bE-cuX">
-                                <rect key="frame" x="130" y="202.5" width="154" height="18"/>
+                                <rect key="frame" x="130" y="204.5" width="154" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Usc-E0-8T2">
-                                <rect key="frame" x="107" y="234.5" width="200" height="25"/>
+                                <rect key="frame" x="107" y="236.5" width="200" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="25" id="5jJ-cF-91C"/>
                                 </constraints>
@@ -159,26 +161,26 @@
                                 <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gAS-qG-sjC">
-                                <rect key="frame" x="107" y="259.5" width="200" height="2"/>
+                                <rect key="frame" x="107" y="261.5" width="200" height="2"/>
                                 <color key="backgroundColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="a4P-Db-9gI"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PASSWORD MATCH" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lbt-1T-cxR">
-                                <rect key="frame" x="137.5" y="281.5" width="139" height="18"/>
+                                <rect key="frame" x="137.5" y="283.5" width="139" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.2274509804" green="0.84313725490000002" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PASSWORD STRENGTH" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B24-oE-KYr">
-                                <rect key="frame" x="124" y="322.5" width="166" height="18"/>
+                                <rect key="frame" x="124" y="324.5" width="166" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <progressView contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mgJ-Mp-brz">
-                                <rect key="frame" x="117" y="346.5" width="180" height="8"/>
+                                <rect key="frame" x="117" y="348.5" width="180" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="180" id="5s8-sK-y1J"/>
@@ -188,7 +190,7 @@
                                 <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </progressView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zde-un-syx" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="157" y="377.5" width="100" height="40"/>
+                                <rect key="frame" x="157" y="379.5" width="100" height="40"/>
                                 <color key="backgroundColor" red="0.160430342" green="0.43735861780000002" blue="0.99941736459999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="38B-wx-DMm"/>

--- a/Decred Wallet/Features/Security/Security.storyboard
+++ b/Decred Wallet/Features/Security/Security.storyboard
@@ -44,7 +44,7 @@
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b4m-te-ci6">
                                                 <rect key="frame" x="207" y="0.0" width="207" height="40"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="backgroundColor" red="0.95294117647058818" green="0.96078431372549022" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
                                                 <state key="normal" title="PIN">
                                                     <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 </state>
@@ -112,13 +112,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Security Password" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c3o-om-jRL">
-                                <rect key="frame" x="101.5" y="74" width="211" height="25.5"/>
+                                <rect key="frame" x="91" y="74" width="232" height="23.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                 <color key="textColor" red="0.039215686270000001" green="0.08235294118" blue="0.2470588235" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PASSWORD" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3VC-gV-ewC">
-                                <rect key="frame" x="165.5" y="119.5" width="83" height="21"/>
+                                <rect key="frame" x="165.5" y="117.5" width="83" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="Km3-3m-m17"/>
                                 </constraints>
@@ -127,7 +127,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zDA-08-WIe">
-                                <rect key="frame" x="107" y="154.5" width="200" height="25"/>
+                                <rect key="frame" x="107" y="152.5" width="200" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Iem-g2-gKG"/>
                                     <constraint firstAttribute="height" constant="25" id="Jlf-hF-RSv"/>
@@ -137,20 +137,20 @@
                                 <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oBs-BE-f5z">
-                                <rect key="frame" x="107" y="179.5" width="200" height="2"/>
+                                <rect key="frame" x="107" y="177.5" width="200" height="2"/>
                                 <color key="backgroundColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="Q4g-4g-dZ0"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONFIRM PASSWORD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lAl-bE-cuX">
-                                <rect key="frame" x="130" y="204.5" width="154" height="18"/>
+                                <rect key="frame" x="130" y="202.5" width="154" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" tag="10" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Usc-E0-8T2">
-                                <rect key="frame" x="107" y="236.5" width="200" height="25"/>
+                                <rect key="frame" x="107" y="234.5" width="200" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="25" id="5jJ-cF-91C"/>
                                 </constraints>
@@ -159,26 +159,26 @@
                                 <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gAS-qG-sjC">
-                                <rect key="frame" x="107" y="261.5" width="200" height="2"/>
+                                <rect key="frame" x="107" y="259.5" width="200" height="2"/>
                                 <color key="backgroundColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="a4P-Db-9gI"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PASSWORD MATCH" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lbt-1T-cxR">
-                                <rect key="frame" x="137.5" y="283.5" width="139" height="18"/>
+                                <rect key="frame" x="137.5" y="281.5" width="139" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.2274509804" green="0.84313725490000002" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PASSWORD STRENGTH" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B24-oE-KYr">
-                                <rect key="frame" x="124" y="324.5" width="166" height="18"/>
+                                <rect key="frame" x="124" y="322.5" width="166" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <progressView contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mgJ-Mp-brz">
-                                <rect key="frame" x="117" y="348.5" width="180" height="8"/>
+                                <rect key="frame" x="117" y="346.5" width="180" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="180" id="5s8-sK-y1J"/>
@@ -188,7 +188,7 @@
                                 <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </progressView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zde-un-syx" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="157" y="379.5" width="100" height="40"/>
+                                <rect key="frame" x="157" y="377.5" width="100" height="40"/>
                                 <color key="backgroundColor" red="0.160430342" green="0.43735861780000002" blue="0.99941736459999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="38B-wx-DMm"/>

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -46,10 +46,11 @@ class SecurityViewController: SecurityBaseViewController {
     }
     
     override func viewDidLoad() {
+        self.btnPassword.setBackgroundColor(UIColor.appColors.transparentThinGray, for: .highlighted)
+        self.btnPin.setBackgroundColor(UIColor.appColors.transparentThinGray, for: .highlighted)
+        
         // delay before activating initial tab to allow borders show properly
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.btnPassword.setBackgroundColor(UIColor.appColors.transparentThinGray, for: .highlighted)
-            self.btnPin.setBackgroundColor(UIColor.appColors.transparentThinGray, for: .highlighted)
             if self.initialSecurityType == SecurityViewController.SECURITY_TYPE_PIN {
                 self.activatePinTab()
             } else {

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -48,6 +48,8 @@ class SecurityViewController: SecurityBaseViewController {
     override func viewDidLoad() {
         // delay before activating initial tab to allow borders show properly
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+             self.btnPassword.setBackgroundColor(UIColor.appColors.lightTabInactive, for: .highlighted)
+             self.btnPin.setBackgroundColor(UIColor.appColors.lightTabInactive, for: .highlighted)
             if self.initialSecurityType == SecurityViewController.SECURITY_TYPE_PIN {
                 self.activatePinTab()
             } else {
@@ -67,24 +69,22 @@ class SecurityViewController: SecurityBaseViewController {
     }
     
     func activatePasswordTab() {
-        tabController?.selectedIndex = 0
+        self.tabController?.selectedIndex = 0
         // activate password button
-        btnPassword.setTitleColor(UIColor.appColors.tabActive, for: .normal)
-        btnPassword.setBackgroundColor(UIColor.appColors.highlightActive, for: .highlighted)
-        btnPassword.addBorder(atPosition: .bottom)
+        self.btnPassword.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        self.btnPassword.addBorder(atPosition: .bottom)
         // deactivate pin button
-        btnPin.setBackgroundColor(UIColor.appColors.highlightActive, for: .highlighted)
-        btnPin.setTitleColor(UIColor.appColors.tabInActive, for: .normal)
-        btnPin.removeBorders(atPositions: .bottom)
+        self.btnPin.setTitleColor(UIColor.appColors.tabInactive, for: .normal)
+        self.btnPin.removeBorders(atPositions: .bottom)
     }
     
     func activatePinTab() {
-        tabController?.selectedIndex = 1
+        self.tabController?.selectedIndex = 1
         // activate pin button
-        btnPin.setTitleColor(UIColor.appColors.tabActive, for: .normal)
-        btnPin.addBorder(atPosition: .bottom)
+        self.btnPin.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        self.btnPin.addBorder(atPosition: .bottom)
         // deactivate password button
-        btnPassword.setTitleColor(UIColor.appColors.tabInActive, for: .normal)
-        btnPassword.removeBorders(atPositions: .bottom)
+        self.btnPassword.setTitleColor(UIColor.appColors.tabInactive, for: .normal)
+        self.btnPassword.removeBorders(atPositions: .bottom)
     }
 }

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -69,20 +69,21 @@ class SecurityViewController: SecurityBaseViewController {
     func activatePasswordTab() {
         tabController?.selectedIndex = 0
         // activate password button
-        btnPassword.backgroundColor = UIColor.appColors.offWhite
-        btnPassword.removeBorders(atPositions: .right, .bottom)
+        btnPassword.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        btnPassword.addBorder(atPosition: .bottom)
         // deactivate pin button
-        btnPin.backgroundColor = UIColor.white
-        btnPin.addBorders(atPositions: [.left, .bottom])
+        btnPin.setTitleColor(UIColor.appColors.tabInActive, for: .normal)
+        btnPin.removeBorders(atPositions: .bottom)
     }
     
     func activatePinTab() {
         tabController?.selectedIndex = 1
         // activate pin button
-        btnPin.backgroundColor = UIColor.appColors.offWhite
-        btnPin.removeBorders(atPositions: .left, .bottom)
+        btnPin.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        btnPin.addBorder(atPosition: .bottom)
         // deactivate password button
-        btnPassword.backgroundColor = UIColor.white
-        btnPassword.addBorders(atPositions: [.right, .bottom])
+        btnPassword.setTitleColor(UIColor.appColors.tabInActive, for: .normal)
+        btnPassword.removeBorders(atPositions: .bottom)
     }
 }
+

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -70,8 +70,10 @@ class SecurityViewController: SecurityBaseViewController {
         tabController?.selectedIndex = 0
         // activate password button
         btnPassword.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        btnPassword.setBackgroundColor(UIColor.appColors.highlightActive, for: .highlighted)
         btnPassword.addBorder(atPosition: .bottom)
         // deactivate pin button
+        btnPin.setBackgroundColor(UIColor.appColors.highlightActive, for: .highlighted)
         btnPin.setTitleColor(UIColor.appColors.tabInActive, for: .normal)
         btnPin.removeBorders(atPositions: .bottom)
     }

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -48,8 +48,8 @@ class SecurityViewController: SecurityBaseViewController {
     override func viewDidLoad() {
         // delay before activating initial tab to allow borders show properly
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-             self.btnPassword.setBackgroundColor(UIColor.appColors.lightTabInactive, for: .highlighted)
-             self.btnPin.setBackgroundColor(UIColor.appColors.lightTabInactive, for: .highlighted)
+            self.btnPassword.setBackgroundColor(UIColor.appColors.transparentThinGray, for: .highlighted)
+            self.btnPin.setBackgroundColor(UIColor.appColors.transparentThinGray, for: .highlighted)
             if self.initialSecurityType == SecurityViewController.SECURITY_TYPE_PIN {
                 self.activatePinTab()
             } else {
@@ -71,20 +71,20 @@ class SecurityViewController: SecurityBaseViewController {
     func activatePasswordTab() {
         self.tabController?.selectedIndex = 0
         // activate password button
-        self.btnPassword.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        self.btnPassword.setTitleColor(UIColor.appColors.darkGray, for: .normal)
         self.btnPassword.addBorder(atPosition: .bottom)
         // deactivate pin button
-        self.btnPin.setTitleColor(UIColor.appColors.tabInactive, for: .normal)
+        self.btnPin.setTitleColor(UIColor.appColors.thinGray, for: .normal)
         self.btnPin.removeBorders(atPositions: .bottom)
     }
     
     func activatePinTab() {
         self.tabController?.selectedIndex = 1
         // activate pin button
-        self.btnPin.setTitleColor(UIColor.appColors.tabActive, for: .normal)
+        self.btnPin.setTitleColor(UIColor.appColors.darkGray, for: .normal)
         self.btnPin.addBorder(atPosition: .bottom)
         // deactivate password button
-        self.btnPassword.setTitleColor(UIColor.appColors.tabInactive, for: .normal)
+        self.btnPassword.setTitleColor(UIColor.appColors.thinGray, for: .normal)
         self.btnPassword.removeBorders(atPositions: .bottom)
     }
 }

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -86,4 +86,3 @@ class SecurityViewController: SecurityBaseViewController {
         btnPassword.removeBorders(atPositions: .bottom)
     }
 }
-


### PR DESCRIPTION
closes #468 
<img src="https://user-images.githubusercontent.com/794430/59386781-7d977c00-8d5f-11e9-8604-0a935e811e94.png" width="300">
<img src="https://user-images.githubusercontent.com/794430/59387193-7886fc80-8d60-11e9-95b2-53dc49a65e95.png" width="300">
![security page](https://user-images.githubusercontent.com/794430/59400057-04fbe400-8d8e-11e9-9fd5-8d2364396eb7.gif)
