### PR TITLE
Restart sync if it stalls for 30 seconds

### DIFF
--- a/Decred Wallet/Features/Navigation Menu/NavigationMenuViewController.swift
+++ b/Decred Wallet/Features/Navigation Menu/NavigationMenuViewController.swift
@@ -186,8 +186,8 @@ extension NavigationMenuViewController: SyncProgressListenerProtocol {
         self.syncStatusLabel.text = "Restarting sync..."
     }
     
-    func onStarted() {
-        self.syncStatusLabel.text = "Connecting to peers."
+    func onStarted(_ wasRestarted: Bool) {
+        self.syncStatusLabel.text = wasRestarted ? "Restarting sync..." : "Connecting to peers."
     }
     
     func onPeerConnectedOrDisconnected(_ numberOfConnectedPeers: Int32) {

--- a/Decred Wallet/Features/Overview/SyncProgressViewController.swift
+++ b/Decred Wallet/Features/Overview/SyncProgressViewController.swift
@@ -94,8 +94,8 @@ class SyncProgressViewController: UIViewController {
 }
 
 extension SyncProgressViewController: SyncProgressListenerProtocol {
-    func onStarted() {
-        self.syncHeaderLabel.text = "Loading..."
+    func onStarted(_ wasRestarted: Bool) {
+        self.syncHeaderLabel.text = wasRestarted ? "Restarting Synchronization" : "Starting Synchronization"
     }
     
     func onPeerConnectedOrDisconnected(_ numberOfConnectedPeers: Int32) {


### PR DESCRIPTION
Resolves #459 

If sync stalls (no sync update is received after 30 seconds), sync operation is restarted to prevent showing high ETA:
<img width="300" alt="Screenshot 2019-06-18 at 2 04 04 AM" src="https://user-images.githubusercontent.com/18400051/59646161-89bf7700-916d-11e9-9a65-ef83b4ae8734.png">
