### PR TITLE
new wallet->verify seed: fix seed word selection scrambling on page scroll

### DIFF
--- a/Decred Wallet/Features/Wallet Setup/ConfirmNewWalletSeedViewController.swift
+++ b/Decred Wallet/Features/Wallet Setup/ConfirmNewWalletSeedViewController.swift
@@ -109,12 +109,10 @@ extension ConfirmNewWalletSeedViewController: UITableViewDelegate, UITableViewDa
         let cell = tableView.dequeueReusableCell(withIdentifier: "tripleSeedCell", for: indexPath) as? SeedConfirmTableViewCell
         
         let userSelection = self.selectedWords[indexPath.row]
-        print(indexPath.row, userSelection)
         cell?.setup(num: indexPath.row, seedWords: seedWordsGroupedByThree[indexPath.row], selectedWord: userSelection)
         
         cell?.onPick = {(index, seedWord) in
             self.selectedWords[indexPath.row] = seedWord
-            print(indexPath.row, seedWord)
             
             self.btnConfirm.isEnabled = self.selectedWords.reduce(true, { (res, input) -> Bool in
                 return res && input != ""

--- a/Decred Wallet/Features/Wallet Setup/ConfirmNewWalletSeedViewController.swift
+++ b/Decred Wallet/Features/Wallet Setup/ConfirmNewWalletSeedViewController.swift
@@ -11,21 +11,46 @@ import Dcrlibwallet
 import JGProgressHUD
 
 class ConfirmNewWalletSeedViewController: WalletSetupBaseViewController {
-    var seedToVerify: String?
-    var selectedSeedWords: [Int] = []
-    var allWords: [String] = []
-    var enteredWords: [String] = []
+    var seedWordsGroupedByThree: [[String]] = []
+    var selectedWords: [String] = []
     
     @IBOutlet weak var btnConfirm: UIButton!
     @IBOutlet var vActiveCellView: SeedCheckActiveCellView!
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        allWords = loadSeedWordsList()
-        for _ in 0...32 {
-            selectedSeedWords.append(-1)
-            enteredWords.append("")
+    func prepareSeedForVerification(seedToVerify: String) {
+        let allSeedWords = loadSeedWordsList()
+        let validSeedWords = seedToVerify.split{$0 == " "}.map(String.init)
+        
+        for seedIndex in 0...32 {
+            let seedWordsGrouped = self.breakdownByThree(allSeedWords, validSeedWordToInclude: validSeedWords[seedIndex])
+            self.seedWordsGroupedByThree.append(seedWordsGrouped)
+            self.selectedWords.append("")
         }
+    }
+    
+    private func breakdownByThree(_ allSeedWords: [String], validSeedWordToInclude: String) -> [String] {
+        var suggestionsWithFake: [String] = ["", "", ""]
+        let trueSeedIndex = Int.random(in: 0...2)
+        suggestionsWithFake[trueSeedIndex] = validSeedWordToInclude
+        
+        let fakeWordsArray = allSeedWords.filter({
+            return ($0.lowercased() != validSeedWordToInclude.lowercased())
+        })
+        
+        var fakeWordsSet = Array(Set(fakeWordsArray))
+        let fake1 = Int.random(in: 0...(fakeWordsSet.count) - 1)
+        var fakes = [fakeWordsSet.remove(at: fake1)]
+        let fake2 = Int.random(in: 0...(fakeWordsSet.count) - 1)
+        fakes.append(fakeWordsSet.remove(at: fake2))
+        var fakeIndex = 0
+        for i in 0...2 {
+            if i != trueSeedIndex {
+                suggestionsWithFake[i] = fakes[fakeIndex]
+                fakeIndex += 1
+            }
+        }
+        
+        return  suggestionsWithFake
     }
     
     @IBAction func backbtn(_ sender: Any) {
@@ -33,7 +58,7 @@ class ConfirmNewWalletSeedViewController: WalletSetupBaseViewController {
     }
     
     @IBAction func onConfirm(_ sender: Any) {
-        let seed = enteredWords.joined(separator: " ")
+        let seed = selectedWords.joined(separator: " ")
         let seedIsValid = DcrlibwalletVerifySeed(seed)
         if seedIsValid {
             self.secureWallet()
@@ -43,7 +68,7 @@ class ConfirmNewWalletSeedViewController: WalletSetupBaseViewController {
     }
     
     func secureWallet() {
-        let seed = enteredWords.joined(separator: " ")
+        let seed = selectedWords.joined(separator: " ")
         let securityVC = SecurityViewController.instantiate()
         securityVC.onUserEnteredPinOrPassword = { (pinOrPassword, securityType) in
             self.finalizeWalletSetup(seed, pinOrPassword, securityType)
@@ -67,31 +92,31 @@ class ConfirmNewWalletSeedViewController: WalletSetupBaseViewController {
     }
 }
 
-extension ConfirmNewWalletSeedViewController: UITableViewDelegate{
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.beginUpdates()
-        tableView.endUpdates()
-    }
+extension ConfirmNewWalletSeedViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 80
     }
-}
-
-extension ConfirmNewWalletSeedViewController: UITableViewDataSource{
     
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int{
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 33
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "tripleSeedCell", for: indexPath) as? SeedConfirmTableViewCell
-        cell?.setup(num: indexPath.row, seedWords: breakdownByThree(row: indexPath.row), selected:pickSelected(row: indexPath.row))
+        
+        let userSelection = self.selectedWords[indexPath.row]
+        print(indexPath.row, userSelection)
+        cell?.setup(num: indexPath.row, seedWords: seedWordsGroupedByThree[indexPath.row], selectedWord: userSelection)
         
         cell?.onPick = {(index, seedWord) in
-            self.selectedSeedWords[indexPath.row] = index
-            self.enteredWords[indexPath.row] = seedWord
+            self.selectedWords[indexPath.row] = seedWord
+            print(indexPath.row, seedWord)
             
-            self.btnConfirm.isEnabled = self.enteredWords.reduce(true, { (res, input) -> Bool in
+            self.btnConfirm.isEnabled = self.selectedWords.reduce(true, { (res, input) -> Bool in
                 return res && input != ""
             })
             
@@ -106,44 +131,5 @@ extension ConfirmNewWalletSeedViewController: UITableViewDataSource{
         }
         
         return cell!
-    }
-    
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-    
-    private func breakdownByThree(row:Int) -> [String]{
-        let seed = seedToVerify?.split{$0 == " "}.map(String.init)
-        
-        var suggestionsWithFake: [String] = ["","",""]
-        let trueSeedIndex = Int.random(in: 0...2)
-        let trueSeed = seed?[row]
-        suggestionsWithFake[trueSeedIndex] = trueSeed ?? "dummy"
-        
-        let fakeWordsArray = allWords.filter({
-            return ($0.lowercased() != trueSeed?.lowercased())
-        })
-        var fakeWordsSet = Array(Set(fakeWordsArray))
-        let fake1 = Int.random(in: 0...(fakeWordsSet.count) - 1)
-        var fakes = [fakeWordsSet.remove(at: fake1)]
-        let fake2 = Int.random(in: 0...(fakeWordsSet.count) - 1)
-        fakes.append(fakeWordsSet.remove(at: fake2))
-        var fakeIndex = 0
-        for i in 0...2 {
-            if i != trueSeedIndex {
-                    suggestionsWithFake[i] = fakes[fakeIndex]
-                    fakeIndex += 1
-            }
-        }
-        
-        return  suggestionsWithFake
-    }
-    
-    private func pickSelected(row: Int) -> Int{
-        if selectedSeedWords.count > row {
-            return selectedSeedWords[row]
-        } else {
-            return -1
-        }
     }
 }

--- a/Decred Wallet/Features/Wallet Setup/CreateNewWalletViewController.swift
+++ b/Decred Wallet/Features/Wallet Setup/CreateNewWalletViewController.swift
@@ -85,7 +85,7 @@ class CreateNewWalletViewController: WalletSetupBaseViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let confirmSeedVC = segue.destination as! ConfirmNewWalletSeedViewController
-        confirmSeedVC.seedToVerify = self.seed
+        confirmSeedVC.prepareSeedForVerification(seedToVerify: self.seed)
     }
     
     @IBAction func backAction(_ sender: UIButton) {

--- a/Decred Wallet/table_view_cell/SeedConfirmTableViewCell.swift
+++ b/Decred Wallet/table_view_cell/SeedConfirmTableViewCell.swift
@@ -22,17 +22,16 @@ class SeedConfirmTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
     
-    func setup(num:Int, seedWords:[String], selected: Int){
+    func setup(num: Int, seedWords: [String], selectedWord: String) {
         btnSeed1.setTitle(seedWords[0], for: .normal)
         btnSeed2.setTitle(seedWords[1], for: .normal)
         btnSeed3.setTitle(seedWords[2], for: .normal)
         
         let buttons = [btnSeed1, btnSeed2, btnSeed3]
-        let _ = buttons.map({$0?.isSelected = false})
+        let _ = buttons.map({ button in
+            button?.isSelected = button?.title(for: .normal) == selectedWord
+        })
         
-        if (selected >= 0) {
-            buttons[selected]?.isSelected = true
-        }
         seedWordNumber = num
         lbWordTitle.text = String(format: LocalizedStrings.wordNumber, num + 1)
     }


### PR DESCRIPTION
Resolves #481.

Current behaviour randomises the 3 words displayed per row every time a row is displayed.

If a row is scrolled out of view and back into view, the 3 words displayed on that row do not match what was displayed prior to scrolling, and the new set of words displayed might not contain the word the user selected before scrolling.

The fix: generate the 3-seed-word groupings before the list is displayed for selection and maintain the grouping/arrangement of the seed words as long as the page remains open.