### PR TITLE
Adopt dcrlibwallet RestartSpvSync method to fix app restart sync issues

### DIFF
--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -1076,7 +1076,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.mainnet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.testnet3;
 				PRODUCT_NAME = "$(TARGET_NAME) Testnet";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1159,7 +1159,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.mainnet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.testnet3;
 				PRODUCT_NAME = "$(TARGET_NAME) Testnet";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/Decred Wallet/Features/Navigation Menu/NavigationMenuViewController.swift
+++ b/Decred Wallet/Features/Navigation Menu/NavigationMenuViewController.swift
@@ -251,9 +251,9 @@ extension NavigationMenuViewController: SyncProgressListenerProtocol {
         AppDelegate.walletLoader.notification.registerListener(for: "\(self)", newTxistener: self)
     }
     
-    func onSyncCanceled() {
+    func onSyncCanceled(_ willRestart: Bool) {
         self.resetSyncViews()
-        self.syncStatusLabel.text = LocalizedStrings.syncCanceled
+        self.syncStatusLabel.text = willRestart ? LocalizedStrings.restartingSync : LocalizedStrings.syncCanceled
     }
     
     func onSyncEndedWithError(_ error: String) {

--- a/Decred Wallet/Features/Overview/SyncProgressViewController.swift
+++ b/Decred Wallet/Features/Overview/SyncProgressViewController.swift
@@ -159,9 +159,9 @@ extension SyncProgressViewController: SyncProgressListenerProtocol {
         self.afterSyncCompletes?()
     }
     
-    func onSyncCanceled() {
+    func onSyncCanceled(_ willRestart: Bool) {
         self.resetSyncViews()
-        self.syncHeaderLabel.text = LocalizedStrings.synchronizationCanceled
+        self.syncHeaderLabel.text = willRestart ? LocalizedStrings.restartingSynchronization : LocalizedStrings.synchronizationCanceled
     }
     
     func onSyncEndedWithError(_ error: String) {


### PR DESCRIPTION
closes #492
Tapping to restart synchronization shows a "sync_in_progress" error message if the wallet is already synced. This is fixed in the new dcrlibwallet RestartSync methods added in https://github.com/raedahgroup/dcrlibwallet/pull/51. This PR updates the dcrios `tap to restart` feature to use the new `RestartSpvSync` method.

This fix also **ensures** that the `tap to restart` feature utilizes any persistent peer address set by a user in the settings page.

Also, the app bundle ID for the testnet build variant is corrected to `com.decred.dcrios.testnet3`. Mainnet build remains `com.decred.dcrios.mainnet`.

NOTE: https://github.com/raedahgroup/dcrlibwallet/pull/51 is required to build this PR.