### PR TITLE
Update pin/pass presentation style by mockup

### DIFF
--- a/Decred Wallet/Features/App Launch/StartScreenViewController.swift
+++ b/Decred Wallet/Features/App Launch/StartScreenViewController.swift
@@ -80,20 +80,24 @@ class StartScreenViewController: UIViewController {
             let requestPasswordVC = RequestPasswordViewController.instantiate()
             requestPasswordVC.securityFor = LocalizedStrings.startup
             requestPasswordVC.prompt = LocalizedStrings.enterStartupPassword
-            requestPasswordVC.modalPresentationStyle = .fullScreen
+            requestPasswordVC.modalPresentationStyle = .pageSheet
             requestPasswordVC.submitBtnText = LocalizedStrings.unlock
             requestPasswordVC.onUserEnteredSecurityCode = self.unlockWalletAndStartApp
             requestPasswordVC.showCancelButton = false
-            self.present(requestPasswordVC, animated: true, completion: nil)
+            self.present(requestPasswordVC, animated: true, completion: {
+              requestPasswordVC.presentationController?.presentedView?.gestureRecognizers?[0].isEnabled = false
+            })
         } else {
             let requestPinVC = RequestPinViewController.instantiate()
             requestPinVC.securityFor = LocalizedStrings.startup
-            requestPinVC.modalPresentationStyle = .fullScreen
+            requestPinVC.modalPresentationStyle = .pageSheet
             requestPinVC.onUserEnteredSecurityCode = self.unlockWalletAndStartApp
             requestPinVC.prompt = LocalizedStrings.unlockWithStartupPIN
             requestPinVC.submitBtnText = LocalizedStrings.unlock
             requestPinVC.showCancelButton = false
-            self.present(requestPinVC, animated: true, completion: nil)
+            self.present(requestPinVC, animated: true, completion: {
+              requestPinVC.presentationController?.presentedView?.gestureRecognizers?[0].isEnabled = false
+            })
         }
     }
 

--- a/Decred Wallet/Features/Security/Security.storyboard
+++ b/Decred Wallet/Features/Security/Security.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -20,76 +22,107 @@
             <objects>
                 <viewController storyboardIdentifier="SecurityViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="oDz-Lc-3bI" customClass="SecurityViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tpH-7I-N4D">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create a spending password" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AyE-8L-BDu">
-                                <rect key="frame" x="24" y="24" width="552" height="23.5"/>
-                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="20"/>
-                                <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="pw2-ld-DVo">
-                                <rect key="frame" x="0.0" y="55.5" width="600" height="48"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qDX-id-rLK">
+                                <rect key="frame" x="0.0" y="391.5" width="414" height="504.5"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FZP-4b-65P">
-                                        <rect key="frame" x="0.0" y="0.0" width="300" height="48"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
-                                        <state key="normal" title="Password">
-                                            <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="password"/>
-                                        </userDefinedRuntimeAttributes>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create a spending password" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AyE-8L-BDu">
+                                        <rect key="frame" x="20" y="24" width="394" height="25.5"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="20"/>
+                                        <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="pw2-ld-DVo">
+                                        <rect key="frame" x="0.0" y="51.5" width="414" height="45"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FZP-4b-65P">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="45"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                                <state key="normal" title="Password">
+                                                    <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                </state>
+                                                <state key="disabled">
+                                                    <color key="titleColor" red="0.76862745098039209" green="0.79607843137254897" blue="0.82352941176470584" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="password"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="onPasswordTab:" destination="oDz-Lc-3bI" eventType="touchUpInside" id="Djs-C0-rE0"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b4m-te-ci6">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="45"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                                <state key="normal" title="PIN">
+                                                    <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                </state>
+                                                <state key="disabled">
+                                                    <color key="titleColor" red="0.76862745098039209" green="0.79607843137254897" blue="0.82352941176470584" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="pin"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="onPinTab:" destination="oDz-Lc-3bI" eventType="touchUpInside" id="DSY-Jd-bXa"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="45" id="eBu-En-pMS"/>
+                                        </constraints>
+                                    </stackView>
+                                    <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yl8-6v-mJ9">
+                                        <rect key="frame" x="0.0" y="104.5" width="414" height="400"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="400" id="X44-Hh-QSz"/>
+                                        </constraints>
                                         <connections>
-                                            <action selector="onPasswordTab:" destination="oDz-Lc-3bI" eventType="touchUpInside" id="Djs-C0-rE0"/>
+                                            <segue destination="XbJ-6W-YLg" kind="embed" identifier="loadTabBarController" id="zi6-tb-yQd"/>
                                         </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b4m-te-ci6">
-                                        <rect key="frame" x="300" y="0.0" width="300" height="48"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
-                                        <state key="normal" title="PIN">
-                                            <color key="titleColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="pin"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="onPinTab:" destination="oDz-Lc-3bI" eventType="touchUpInside" id="DSY-Jd-bXa"/>
-                                        </connections>
-                                    </button>
+                                    </containerView>
                                 </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="48" id="eBu-En-pMS"/>
+                                    <constraint firstItem="AyE-8L-BDu" firstAttribute="top" secondItem="qDX-id-rLK" secondAttribute="top" constant="24" id="65V-k6-Kte"/>
+                                    <constraint firstAttribute="trailing" secondItem="pw2-ld-DVo" secondAttribute="trailing" id="6P6-wg-h0H"/>
+                                    <constraint firstAttribute="trailing" secondItem="AyE-8L-BDu" secondAttribute="trailing" id="BC5-4l-zMq"/>
+                                    <constraint firstItem="Yl8-6v-mJ9" firstAttribute="top" secondItem="pw2-ld-DVo" secondAttribute="bottom" constant="8" symbolic="YES" id="GFJ-Up-khv"/>
+                                    <constraint firstItem="pw2-ld-DVo" firstAttribute="leading" secondItem="qDX-id-rLK" secondAttribute="leading" id="Ps3-o9-Lu7"/>
+                                    <constraint firstAttribute="trailing" secondItem="Yl8-6v-mJ9" secondAttribute="trailing" id="WsX-ln-JJg"/>
+                                    <constraint firstAttribute="bottom" secondItem="Yl8-6v-mJ9" secondAttribute="bottom" id="hgI-yt-opP"/>
+                                    <constraint firstItem="pw2-ld-DVo" firstAttribute="top" secondItem="AyE-8L-BDu" secondAttribute="bottom" constant="2" id="nOP-Vg-XIr"/>
+                                    <constraint firstItem="AyE-8L-BDu" firstAttribute="leading" secondItem="qDX-id-rLK" secondAttribute="leading" constant="20" symbolic="YES" id="uIq-FL-bvx"/>
+                                    <constraint firstItem="Yl8-6v-mJ9" firstAttribute="leading" secondItem="qDX-id-rLK" secondAttribute="leading" id="xnd-Uo-8en"/>
                                 </constraints>
-                            </stackView>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yl8-6v-mJ9">
-                                <rect key="frame" x="0.0" y="103.5" width="600" height="497.5"/>
-                                <connections>
-                                    <segue destination="XbJ-6W-YLg" kind="embed" identifier="loadTabBarController" id="zi6-tb-yQd"/>
-                                </connections>
-                            </containerView>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="14"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.maskedCorners">
+                                        <integer key="value" value="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Yl8-6v-mJ9" firstAttribute="top" secondItem="pw2-ld-DVo" secondAttribute="bottom" id="0MZ-QI-6es"/>
-                            <constraint firstItem="pw2-ld-DVo" firstAttribute="leading" secondItem="dho-lD-rH7" secondAttribute="leading" id="5Gj-FJ-nB6"/>
-                            <constraint firstAttribute="bottomMargin" secondItem="Yl8-6v-mJ9" secondAttribute="bottom" constant="-1" id="Hvq-WT-smj"/>
-                            <constraint firstItem="pw2-ld-DVo" firstAttribute="top" secondItem="AyE-8L-BDu" secondAttribute="bottom" constant="8" id="OIi-Rm-dAh"/>
-                            <constraint firstItem="dho-lD-rH7" firstAttribute="trailing" secondItem="AyE-8L-BDu" secondAttribute="trailing" constant="24" id="Rfu-mY-5s4"/>
-                            <constraint firstItem="dho-lD-rH7" firstAttribute="trailing" secondItem="pw2-ld-DVo" secondAttribute="trailing" id="UTG-vj-C9o"/>
-                            <constraint firstItem="Yl8-6v-mJ9" firstAttribute="leading" secondItem="pw2-ld-DVo" secondAttribute="leading" id="eYQ-eH-KAD"/>
-                            <constraint firstItem="Yl8-6v-mJ9" firstAttribute="trailing" secondItem="pw2-ld-DVo" secondAttribute="trailing" id="g7F-J7-LbV"/>
-                            <constraint firstItem="AyE-8L-BDu" firstAttribute="leading" secondItem="dho-lD-rH7" secondAttribute="leading" constant="24" id="l1F-o8-aNX"/>
-                            <constraint firstItem="AyE-8L-BDu" firstAttribute="top" secondItem="dho-lD-rH7" secondAttribute="top" constant="24" id="vQQ-vX-af8"/>
+                            <constraint firstItem="qDX-id-rLK" firstAttribute="leading" secondItem="tpH-7I-N4D" secondAttribute="leading" id="4Nr-CV-AzR"/>
+                            <constraint firstAttribute="trailing" secondItem="qDX-id-rLK" secondAttribute="trailing" id="I8S-TY-oca"/>
+                            <constraint firstAttribute="bottom" secondItem="qDX-id-rLK" secondAttribute="bottom" id="mfq-1P-bwU"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="dho-lD-rH7"/>
                     </view>
                     <connections>
                         <outlet property="btnPassword" destination="FZP-4b-65P" id="k70-GQ-K7X"/>
                         <outlet property="btnPin" destination="b4m-te-ci6" id="nNQ-qG-I0q"/>
+                        <outlet property="containerViewHeightConstraint" destination="X44-Hh-QSz" id="Wa6-QR-HwA"/>
                         <outlet property="securityPromptLabel" destination="AyE-8L-BDu" id="ukO-gA-dFm"/>
                     </connections>
                 </viewController>
@@ -121,432 +154,480 @@
             <objects>
                 <viewController storyboardIdentifier="RequestPasswordViewController" title="Password Tab" id="2lq-jW-9IA" customClass="RequestPasswordViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wcl-lB-4xs">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="629.66666666666674"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="oLB-RB-SsP">
-                                <rect key="frame" x="24" y="24" width="327" height="313.5"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VIK-gW-7wr">
+                                <rect key="frame" x="0.0" y="66.5" width="414" height="333.5"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ms-qN-4pQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="327" height="73.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="oLB-RB-SsP">
+                                        <rect key="frame" x="24" y="20" width="366" height="313.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unlock with startup password" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NoT-EV-WHd">
-                                                <rect key="frame" x="0.0" y="24" width="327" height="25.5"/>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="20"/>
-                                                <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
-                                                </userDefinedRuntimeAttributes>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstItem="NoT-EV-WHd" firstAttribute="top" secondItem="0Ms-qN-4pQ" secondAttribute="top" constant="24" id="0pC-FP-PaV"/>
-                                            <constraint firstItem="NoT-EV-WHd" firstAttribute="leading" secondItem="0Ms-qN-4pQ" secondAttribute="leading" id="4MW-pb-fPp"/>
-                                            <constraint firstAttribute="trailing" secondItem="NoT-EV-WHd" secondAttribute="trailing" id="WyT-Tg-HWp"/>
-                                            <constraint firstAttribute="bottom" secondItem="NoT-EV-WHd" secondAttribute="bottom" constant="24" id="hem-da-OHY"/>
-                                        </constraints>
-                                    </view>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Spending password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NMs-Wa-sVv" customClass="FloatingPlaceholderTextField" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="73.5" width="327" height="48"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="48" id="0es-Dm-pTI"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
-                                        <textInputTraits key="textInputTraits" textContentType="password"/>
-                                    </textField>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ewR-2e-MEM">
-                                        <rect key="frame" x="0.0" y="121.5" width="327" height="24"/>
-                                        <subviews>
-                                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Wrong startup password. Please try again." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afa-Zo-Kic">
-                                                <rect key="frame" x="16" y="5" width="250" height="14"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ms-qN-4pQ">
+                                                <rect key="frame" x="0.0" y="0.0" width="366" height="73.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unlock with startup password" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NoT-EV-WHd">
+                                                        <rect key="frame" x="0.0" y="24" width="366" height="25.5"/>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="20"/>
+                                                        <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="250" id="fHR-is-0YA"/>
+                                                    <constraint firstItem="NoT-EV-WHd" firstAttribute="top" secondItem="0Ms-qN-4pQ" secondAttribute="top" constant="24" id="0pC-FP-PaV"/>
+                                                    <constraint firstItem="NoT-EV-WHd" firstAttribute="leading" secondItem="0Ms-qN-4pQ" secondAttribute="leading" id="4MW-pb-fPp"/>
+                                                    <constraint firstAttribute="trailing" secondItem="NoT-EV-WHd" secondAttribute="trailing" id="WyT-Tg-HWp"/>
+                                                    <constraint firstAttribute="bottom" secondItem="NoT-EV-WHd" secondAttribute="bottom" constant="24" id="hem-da-OHY"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
-                                                <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Z3-SY-0XE">
-                                                <rect key="frame" x="281" y="6" width="30" height="12"/>
+                                            </view>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Placeholder" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NMs-Wa-sVv" customClass="FloatingPlaceholderTextField" customModule="Decred_Wallet" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="73.5" width="366" height="48"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="12" id="N7d-SU-etT"/>
+                                                    <constraint firstAttribute="height" constant="48" id="0es-Dm-pTI"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
-                                                <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstItem="afa-Zo-Kic" firstAttribute="top" secondItem="ewR-2e-MEM" secondAttribute="top" constant="5" id="03n-OZ-yIm"/>
-                                            <constraint firstAttribute="trailing" secondItem="2Z3-SY-0XE" secondAttribute="trailing" constant="16" id="7cw-D7-3Ax"/>
-                                            <constraint firstAttribute="bottom" secondItem="2Z3-SY-0XE" secondAttribute="bottom" constant="6" id="Jd0-5D-gxY"/>
-                                            <constraint firstItem="2Z3-SY-0XE" firstAttribute="centerY" secondItem="ewR-2e-MEM" secondAttribute="centerY" id="hxM-AQ-M9a"/>
-                                            <constraint firstAttribute="bottom" secondItem="afa-Zo-Kic" secondAttribute="bottom" constant="5" id="moV-tK-7TJ"/>
-                                            <constraint firstItem="2Z3-SY-0XE" firstAttribute="top" secondItem="ewR-2e-MEM" secondAttribute="top" constant="6" id="mqV-Me-z4U"/>
-                                            <constraint firstItem="2Z3-SY-0XE" firstAttribute="leading" secondItem="afa-Zo-Kic" secondAttribute="trailing" constant="15" id="ui1-oG-7Ds"/>
-                                            <constraint firstItem="afa-Zo-Kic" firstAttribute="leading" secondItem="ewR-2e-MEM" secondAttribute="leading" constant="16" id="vsb-SV-mF8"/>
-                                            <constraint firstItem="afa-Zo-Kic" firstAttribute="centerY" secondItem="ewR-2e-MEM" secondAttribute="centerY" id="xJ0-c1-7xn"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vmK-ZW-8U3">
-                                        <rect key="frame" x="0.0" y="145.5" width="327" height="40"/>
-                                        <subviews>
-                                            <progressView contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f8A-co-8Dp" customClass="ProgressView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="8" width="327" height="8"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                                <textInputTraits key="textInputTraits" textContentType="password"/>
+                                            </textField>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ewR-2e-MEM">
+                                                <rect key="frame" x="0.0" y="121.5" width="366" height="16"/>
+                                                <subviews>
+                                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Wrong startup password. Please try again." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afa-Zo-Kic">
+                                                        <rect key="frame" x="16" y="4" width="250" height="12"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="250" id="fHR-is-0YA"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
+                                                        <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Z3-SY-0XE">
+                                                        <rect key="frame" x="281" y="4" width="69" height="12"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="12" id="N7d-SU-etT"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
+                                                        <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="8" id="XiC-rj-VU9"/>
+                                                    <constraint firstItem="afa-Zo-Kic" firstAttribute="top" secondItem="ewR-2e-MEM" secondAttribute="top" constant="4" id="03n-OZ-yIm"/>
+                                                    <constraint firstAttribute="bottom" secondItem="afa-Zo-Kic" secondAttribute="bottom" id="56t-bt-NZp"/>
+                                                    <constraint firstAttribute="trailing" secondItem="2Z3-SY-0XE" secondAttribute="trailing" constant="16" id="7cw-D7-3Ax"/>
+                                                    <constraint firstAttribute="bottom" secondItem="2Z3-SY-0XE" secondAttribute="bottom" id="Jd0-5D-gxY"/>
+                                                    <constraint firstItem="2Z3-SY-0XE" firstAttribute="top" secondItem="ewR-2e-MEM" secondAttribute="top" constant="4" id="mqV-Me-z4U"/>
+                                                    <constraint firstItem="2Z3-SY-0XE" firstAttribute="leading" secondItem="afa-Zo-Kic" secondAttribute="trailing" constant="15" id="ui1-oG-7Ds"/>
+                                                    <constraint firstItem="afa-Zo-Kic" firstAttribute="leading" secondItem="ewR-2e-MEM" secondAttribute="leading" constant="16" id="vsb-SV-mF8"/>
                                                 </constraints>
-                                                <color key="trackTintColor" red="0.95294117649999999" green="0.96078431369999995" blue="0.96470588239999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </progressView>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstItem="f8A-co-8Dp" firstAttribute="leading" secondItem="vmK-ZW-8U3" secondAttribute="leading" id="UsQ-FF-lXt"/>
-                                            <constraint firstAttribute="trailing" secondItem="f8A-co-8Dp" secondAttribute="trailing" id="WYl-wR-bfp"/>
-                                            <constraint firstItem="f8A-co-8Dp" firstAttribute="top" secondItem="vmK-ZW-8U3" secondAttribute="top" constant="8" id="jzw-Hb-qds"/>
-                                            <constraint firstAttribute="bottom" secondItem="f8A-co-8Dp" secondAttribute="bottom" constant="24" id="pad-fh-UgV"/>
-                                        </constraints>
-                                    </view>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Confirm spending password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Fj4-AU-s5Z" customClass="FloatingPlaceholderTextField" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="185.5" width="327" height="48"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="48" id="q5y-pi-MzY"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
-                                        <textInputTraits key="textInputTraits" textContentType="password"/>
-                                    </textField>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aZX-ec-zBK">
-                                        <rect key="frame" x="0.0" y="233.5" width="327" height="24"/>
-                                        <subviews>
-                                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Password do not match" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zxu-b3-Pxp">
-                                                <rect key="frame" x="16" y="5" width="250" height="14"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vmK-ZW-8U3">
+                                                <rect key="frame" x="0.0" y="137.5" width="366" height="40"/>
+                                                <subviews>
+                                                    <progressView contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f8A-co-8Dp" customClass="ProgressView" customModule="Decred_Wallet" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="8" width="366" height="8"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="8" id="XiC-rj-VU9"/>
+                                                        </constraints>
+                                                        <color key="trackTintColor" red="0.95294117649999999" green="0.96078431369999995" blue="0.96470588239999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </progressView>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="250" id="4EK-eq-gXB"/>
+                                                    <constraint firstItem="f8A-co-8Dp" firstAttribute="leading" secondItem="vmK-ZW-8U3" secondAttribute="leading" id="UsQ-FF-lXt"/>
+                                                    <constraint firstAttribute="trailing" secondItem="f8A-co-8Dp" secondAttribute="trailing" id="WYl-wR-bfp"/>
+                                                    <constraint firstItem="f8A-co-8Dp" firstAttribute="top" secondItem="vmK-ZW-8U3" secondAttribute="top" constant="8" id="jzw-Hb-qds"/>
+                                                    <constraint firstAttribute="bottom" secondItem="f8A-co-8Dp" secondAttribute="bottom" constant="24" id="pad-fh-UgV"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
-                                                <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R4i-8R-w01">
-                                                <rect key="frame" x="281" y="6" width="30" height="12"/>
+                                            </view>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Placeholder" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Fj4-AU-s5Z" customClass="FloatingPlaceholderTextField" customModule="Decred_Wallet" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="177.5" width="366" height="48"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="12" id="EsO-df-841"/>
+                                                    <constraint firstAttribute="height" constant="48" id="q5y-pi-MzY"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
-                                                <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstItem="R4i-8R-w01" firstAttribute="centerY" secondItem="aZX-ec-zBK" secondAttribute="centerY" id="QWW-H7-Pp5"/>
-                                            <constraint firstItem="Zxu-b3-Pxp" firstAttribute="leading" secondItem="aZX-ec-zBK" secondAttribute="leading" constant="16" id="eCV-fG-eWK"/>
-                                            <constraint firstItem="R4i-8R-w01" firstAttribute="leading" secondItem="Zxu-b3-Pxp" secondAttribute="trailing" constant="15" id="lka-h3-vJ9"/>
-                                            <constraint firstItem="Zxu-b3-Pxp" firstAttribute="centerY" secondItem="aZX-ec-zBK" secondAttribute="centerY" id="naK-cp-bgs"/>
-                                            <constraint firstItem="R4i-8R-w01" firstAttribute="top" secondItem="aZX-ec-zBK" secondAttribute="top" constant="6" id="tJZ-81-JNm"/>
-                                            <constraint firstAttribute="bottom" secondItem="R4i-8R-w01" secondAttribute="bottom" constant="6" id="wtN-Q8-LbC"/>
-                                            <constraint firstAttribute="trailing" secondItem="R4i-8R-w01" secondAttribute="trailing" constant="16" id="z76-P9-9SV"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EdM-JP-adU">
-                                        <rect key="frame" x="0.0" y="257.5" width="327" height="56"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v6t-Bu-n8H">
-                                                <rect key="frame" x="161" y="16" width="79" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="79" id="b1J-Cl-bBx"/>
-                                                    <constraint firstAttribute="height" constant="40" id="vKZ-vE-jty"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
-                                                <state key="normal" title="Cancel"/>
+                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                                <textInputTraits key="textInputTraits" textContentType="password"/>
                                                 <connections>
-                                                    <action selector="cancelTapped:" destination="2lq-jW-9IA" eventType="touchUpInside" id="Vej-tw-TUU"/>
+                                                    <action selector="confirmPasswordEditingDidBegin:" destination="2lq-jW-9IA" eventType="editingDidBegin" id="Sfs-cd-PMv"/>
                                                 </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PwE-hW-lVm" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="248" y="16" width="79" height="40"/>
-                                                <color key="backgroundColor" red="0.77000000000000002" green="0.80000000000000004" blue="0.81999999999999995" alpha="1" colorSpace="calibratedRGB"/>
+                                            </textField>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aZX-ec-zBK">
+                                                <rect key="frame" x="0.0" y="225.5" width="366" height="16"/>
+                                                <subviews>
+                                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Password do not match" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zxu-b3-Pxp">
+                                                        <rect key="frame" x="16" y="4" width="250" height="12"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="250" id="4EK-eq-gXB"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
+                                                        <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R4i-8R-w01">
+                                                        <rect key="frame" x="281" y="4" width="69" height="12"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="12" id="EsO-df-841"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
+                                                        <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="Fi5-Lx-dDQ"/>
-                                                    <constraint firstAttribute="width" constant="79" id="k6V-Dj-Feb"/>
+                                                    <constraint firstItem="Zxu-b3-Pxp" firstAttribute="top" secondItem="aZX-ec-zBK" secondAttribute="top" constant="4" id="BUy-6v-l4f"/>
+                                                    <constraint firstItem="Zxu-b3-Pxp" firstAttribute="leading" secondItem="aZX-ec-zBK" secondAttribute="leading" constant="16" id="eCV-fG-eWK"/>
+                                                    <constraint firstAttribute="bottom" secondItem="Zxu-b3-Pxp" secondAttribute="bottom" id="eY9-Bi-5es"/>
+                                                    <constraint firstItem="R4i-8R-w01" firstAttribute="leading" secondItem="Zxu-b3-Pxp" secondAttribute="trailing" constant="15" id="lka-h3-vJ9"/>
+                                                    <constraint firstItem="R4i-8R-w01" firstAttribute="top" secondItem="aZX-ec-zBK" secondAttribute="top" constant="4" id="tJZ-81-JNm"/>
+                                                    <constraint firstAttribute="bottom" secondItem="R4i-8R-w01" secondAttribute="bottom" id="wtN-Q8-LbC"/>
+                                                    <constraint firstAttribute="trailing" secondItem="R4i-8R-w01" secondAttribute="trailing" constant="16" id="z76-P9-9SV"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
-                                                <state key="normal" title="Create">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </state>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="color" keyPath="disabledBackgroundColor">
-                                                        <color key="value" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                        <real key="value" value="7"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="color" keyPath="enabledBackgroundColor">
-                                                        <color key="value" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="createTapped:" destination="2lq-jW-9IA" eventType="touchUpInside" id="LZT-L6-6Ms"/>
-                                                </connections>
-                                            </button>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EdM-JP-adU">
+                                                <rect key="frame" x="0.0" y="241.5" width="366" height="72"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v6t-Bu-n8H">
+                                                        <rect key="frame" x="200" y="8" width="79" height="40"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="79" id="b1J-Cl-bBx"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                                        <state key="normal" title="Cancel"/>
+                                                        <connections>
+                                                            <action selector="cancelTapped:" destination="2lq-jW-9IA" eventType="touchUpInside" id="Vej-tw-TUU"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PwE-hW-lVm" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
+                                                        <rect key="frame" x="287" y="8" width="79" height="40"/>
+                                                        <color key="backgroundColor" red="0.77000000000000002" green="0.80000000000000004" blue="0.81999999999999995" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="40" id="Fi5-Lx-dDQ"/>
+                                                            <constraint firstAttribute="width" constant="79" id="k6V-Dj-Feb"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                                        <state key="normal" title="Create">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="disabledBackgroundColor">
+                                                                <color key="value" red="0.76862745099999996" green="0.79607843140000001" blue="0.82352941180000006" alpha="1" colorSpace="calibratedRGB"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                <real key="value" value="7"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="enabledBackgroundColor">
+                                                                <color key="value" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="createTapped:" destination="2lq-jW-9IA" eventType="touchUpInside" id="LZT-L6-6Ms"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="PwE-hW-lVm" firstAttribute="top" secondItem="EdM-JP-adU" secondAttribute="top" constant="8" id="a3d-dx-5EF"/>
+                                                    <constraint firstAttribute="trailing" secondItem="PwE-hW-lVm" secondAttribute="trailing" id="obr-C3-S5x"/>
+                                                    <constraint firstAttribute="bottom" secondItem="PwE-hW-lVm" secondAttribute="bottom" constant="24" id="qbf-lk-mij"/>
+                                                    <constraint firstItem="v6t-Bu-n8H" firstAttribute="centerY" secondItem="PwE-hW-lVm" secondAttribute="centerY" id="sHo-J2-eQG"/>
+                                                    <constraint firstItem="v6t-Bu-n8H" firstAttribute="height" secondItem="PwE-hW-lVm" secondAttribute="height" id="uaL-rw-kuG"/>
+                                                    <constraint firstItem="PwE-hW-lVm" firstAttribute="leading" secondItem="v6t-Bu-n8H" secondAttribute="trailing" constant="8" id="x8R-z4-v8S"/>
+                                                </constraints>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstItem="PwE-hW-lVm" firstAttribute="top" secondItem="EdM-JP-adU" secondAttribute="top" constant="16" id="a3d-dx-5EF"/>
-                                            <constraint firstAttribute="trailing" secondItem="PwE-hW-lVm" secondAttribute="trailing" id="obr-C3-S5x"/>
-                                            <constraint firstAttribute="bottom" secondItem="PwE-hW-lVm" secondAttribute="bottom" id="qbf-lk-mij"/>
-                                            <constraint firstItem="v6t-Bu-n8H" firstAttribute="centerY" secondItem="PwE-hW-lVm" secondAttribute="centerY" id="sHo-J2-eQG"/>
-                                            <constraint firstItem="PwE-hW-lVm" firstAttribute="leading" secondItem="v6t-Bu-n8H" secondAttribute="trailing" constant="8" id="x8R-z4-v8S"/>
-                                        </constraints>
-                                    </view>
+                                    </stackView>
                                 </subviews>
-                            </stackView>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="oLB-RB-SsP" firstAttribute="top" secondItem="VIK-gW-7wr" secondAttribute="top" constant="20" symbolic="YES" id="76A-G8-wTO"/>
+                                    <constraint firstAttribute="bottom" secondItem="oLB-RB-SsP" secondAttribute="bottom" id="OEj-Ag-TFl"/>
+                                    <constraint firstAttribute="trailing" secondItem="oLB-RB-SsP" secondAttribute="trailing" constant="24" id="acL-7m-0yx"/>
+                                    <constraint firstItem="oLB-RB-SsP" firstAttribute="leading" secondItem="VIK-gW-7wr" secondAttribute="leading" constant="24" id="p2T-QE-3FK"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="14"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.maskedCorners">
+                                        <integer key="value" value="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="oLB-RB-SsP" firstAttribute="leading" secondItem="YVH-T5-DVQ" secondAttribute="leading" constant="24" id="Hga-SS-MUm"/>
-                            <constraint firstItem="YVH-T5-DVQ" firstAttribute="trailing" secondItem="oLB-RB-SsP" secondAttribute="trailing" constant="24" id="Kic-Oz-eUR"/>
-                            <constraint firstItem="oLB-RB-SsP" firstAttribute="top" secondItem="YVH-T5-DVQ" secondAttribute="top" constant="24" id="hTe-yC-yMw"/>
+                            <constraint firstItem="YVH-T5-DVQ" firstAttribute="trailing" secondItem="VIK-gW-7wr" secondAttribute="trailing" id="Dih-iX-9gB"/>
+                            <constraint firstItem="VIK-gW-7wr" firstAttribute="leading" secondItem="YVH-T5-DVQ" secondAttribute="leading" id="Xxd-Ge-aZV"/>
+                            <constraint firstAttribute="bottom" secondItem="VIK-gW-7wr" secondAttribute="bottom" id="gVi-Bh-esE"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="YVH-T5-DVQ"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Item 1" id="rzl-Y4-kRX"/>
+                    <nil key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="btnCancel" destination="v6t-Bu-n8H" id="WpX-YN-RbS"/>
                         <outlet property="btnSubmit" destination="PwE-hW-lVm" id="jNY-iX-zHW"/>
                         <outlet property="confirmCountLabel" destination="R4i-8R-w01" id="QA2-cO-ZPY"/>
                         <outlet property="confirmErrorLabel" destination="Zxu-b3-Pxp" id="HfF-aY-r0t"/>
                         <outlet property="confirmPasswordInput" destination="Fj4-AU-s5Z" id="Ikp-6r-fCv"/>
+                        <outlet property="containerView" destination="VIK-gW-7wr" id="i8l-N0-3MQ"/>
                         <outlet property="headerLabel" destination="NoT-EV-WHd" id="6Bd-Ad-0SH"/>
                         <outlet property="passwordCountLabel" destination="2Z3-SY-0XE" id="YT8-Mb-FeN"/>
                         <outlet property="passwordErrorLabel" destination="afa-Zo-Kic" id="Ug5-6A-Jxz"/>
                         <outlet property="passwordInput" destination="NMs-Wa-sVv" id="rGJ-1L-J0q"/>
                         <outlet property="passwordStrengthIndicator" destination="f8A-co-8Dp" id="nPZ-4M-b8l"/>
+                        <outlet property="stackViewBottomConstraint" destination="OEj-Ag-TFl" id="Dou-FW-Vqm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BTj-yk-gbD" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6268" y="-786.20689655172418"/>
+            <point key="canvasLocation" x="6267" y="-649"/>
         </scene>
         <!--Pin Tab-->
         <scene sceneID="y31-sl-O1Z">
             <objects>
                 <viewController storyboardIdentifier="RequestPinViewController" title="Pin Tab" useStoryboardIdentifierAsRestorationIdentifier="YES" id="SKa-iY-3vv" customClass="RequestPinViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="MZP-zs-4TF">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="629.66666666666674"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="lgN-j6-puv">
-                                <rect key="frame" x="24" y="0.0" width="327" height="252.5"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fa7-1r-DRV">
+                                <rect key="frame" x="0.0" y="155.5" width="414" height="244.5"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsl-Yq-viG">
-                                        <rect key="frame" x="0.0" y="0.0" width="327" height="73.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="lgN-j6-puv">
+                                        <rect key="frame" x="24" y="0.0" width="366" height="244.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unlock with startup PIN" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LFW-Ta-LtS">
-                                                <rect key="frame" x="0.0" y="24" width="327" height="25.5"/>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="20"/>
-                                                <color key="textColor" red="0.035294117647058823" green="0.078431372549019607" blue="0.25098039215686274" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
-                                                </userDefinedRuntimeAttributes>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="LFW-Ta-LtS" secondAttribute="bottom" constant="24" id="4bg-Xq-KSc"/>
-                                            <constraint firstItem="LFW-Ta-LtS" firstAttribute="leading" secondItem="xsl-Yq-viG" secondAttribute="leading" id="PXx-Bw-Ndj"/>
-                                            <constraint firstAttribute="trailing" secondItem="LFW-Ta-LtS" secondAttribute="trailing" id="S8E-4d-GJn"/>
-                                            <constraint firstItem="LFW-Ta-LtS" firstAttribute="top" secondItem="xsl-Yq-viG" secondAttribute="top" constant="24" id="eE2-md-KS4"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Csj-Rf-u1l">
-                                        <rect key="frame" x="0.0" y="74.5" width="327" height="80"/>
-                                        <subviews>
-                                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Z10-H9-p32">
-                                                <rect key="frame" x="48" y="32" width="243" height="16"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsl-Yq-viG">
+                                                <rect key="frame" x="0.0" y="0.0" width="366" height="73.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unlock with startup PIN" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LFW-Ta-LtS">
+                                                        <rect key="frame" x="0.0" y="24" width="366" height="25.5"/>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="20"/>
+                                                        <color key="textColor" red="0.035294117647058823" green="0.078431372549019607" blue="0.25098039215686274" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </label>
+                                                </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="16" id="voX-Vs-U5n"/>
+                                                    <constraint firstAttribute="bottom" secondItem="LFW-Ta-LtS" secondAttribute="bottom" constant="24" id="4bg-Xq-KSc"/>
+                                                    <constraint firstItem="LFW-Ta-LtS" firstAttribute="leading" secondItem="xsl-Yq-viG" secondAttribute="leading" id="PXx-Bw-Ndj"/>
+                                                    <constraint firstAttribute="trailing" secondItem="LFW-Ta-LtS" secondAttribute="trailing" id="S8E-4d-GJn"/>
+                                                    <constraint firstItem="LFW-Ta-LtS" firstAttribute="top" secondItem="xsl-Yq-viG" secondAttribute="top" constant="24" id="eE2-md-KS4"/>
                                                 </constraints>
-                                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="16" minimumInteritemSpacing="8" id="Qtv-Gu-gSh">
-                                                    <size key="itemSize" width="16" height="16"/>
-                                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                </collectionViewFlowLayout>
-                                                <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PinCell" id="pje-eo-py9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="G6R-9N-UTL">
-                                                            <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
-                                                            <autoresizingMask key="autoresizingMask"/>
-                                                        </collectionViewCellContentView>
-                                                        <color key="backgroundColor" red="0.1764705882352941" green="0.84705882352941175" blue="0.63921568627450975" alpha="1" colorSpace="calibratedRGB"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Csj-Rf-u1l">
+                                                <rect key="frame" x="0.0" y="74.5" width="366" height="72"/>
+                                                <subviews>
+                                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Z10-H9-p32">
+                                                        <rect key="frame" x="48" y="24" width="282" height="16"/>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="16" id="voX-Vs-U5n"/>
+                                                        </constraints>
+                                                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="16" minimumInteritemSpacing="8" id="Qtv-Gu-gSh">
+                                                            <size key="itemSize" width="16" height="16"/>
+                                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                        </collectionViewFlowLayout>
+                                                        <cells>
+                                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PinCell" id="pje-eo-py9">
+                                                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="G6R-9N-UTL">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                                                    <autoresizingMask key="autoresizingMask"/>
+                                                                </collectionViewCellContentView>
+                                                                <color key="backgroundColor" red="0.1764705882352941" green="0.84705882352941175" blue="0.63921568627450975" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                        <integer key="value" value="8"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                            </collectionViewCell>
+                                                        </cells>
+                                                        <connections>
+                                                            <outlet property="dataSource" destination="SKa-iY-3vv" id="da2-Ch-WyQ"/>
+                                                            <outlet property="delegate" destination="SKa-iY-3vv" id="kTA-ks-KxE"/>
+                                                        </connections>
+                                                    </collectionView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter Spending PIN" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cqy-a9-VLC">
+                                                        <rect key="frame" x="118" y="26" width="130" height="20.5"/>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                                        <color key="textColor" red="0.53725490196078429" green="0.59215686274509804" blue="0.6470588235294118" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
                                                         <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                <integer key="value" value="8"/>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </label>
+                                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="16" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TuL-zv-aYr">
+                                                        <rect key="frame" x="354" y="24.5" width="12" height="15.5"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="12" id="zJg-qR-fQV"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
+                                                        <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wrong startup PIN. Please try again." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Tx-gJ-gPY">
+                                                        <rect key="frame" x="99.5" y="56" width="179" height="15.5"/>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
+                                                        <color key="textColor" red="0.92941176470588238" green="0.42745098039215684" blue="0.27843137254901962" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="Z10-H9-p32" secondAttribute="bottom" constant="32" id="3Gz-yl-ZPD"/>
+                                                    <constraint firstItem="Cqy-a9-VLC" firstAttribute="centerX" secondItem="Csj-Rf-u1l" secondAttribute="centerX" id="Du2-iZ-UhQ"/>
+                                                    <constraint firstItem="7Tx-gJ-gPY" firstAttribute="top" secondItem="Z10-H9-p32" secondAttribute="bottom" constant="16" id="PKc-6n-gIe"/>
+                                                    <constraint firstItem="Z10-H9-p32" firstAttribute="top" secondItem="Csj-Rf-u1l" secondAttribute="top" constant="24" id="dXK-di-cwS"/>
+                                                    <constraint firstItem="TuL-zv-aYr" firstAttribute="centerY" secondItem="Z10-H9-p32" secondAttribute="centerY" id="eWE-KB-yKv"/>
+                                                    <constraint firstItem="TuL-zv-aYr" firstAttribute="leading" secondItem="Z10-H9-p32" secondAttribute="trailing" constant="24" id="eua-Lg-T8c"/>
+                                                    <constraint firstItem="7Tx-gJ-gPY" firstAttribute="centerX" secondItem="Z10-H9-p32" secondAttribute="centerX" id="iMt-C1-TRQ"/>
+                                                    <constraint firstItem="Z10-H9-p32" firstAttribute="leading" secondItem="Csj-Rf-u1l" secondAttribute="leading" constant="48" id="j2k-eM-75d"/>
+                                                    <constraint firstAttribute="trailing" secondItem="TuL-zv-aYr" secondAttribute="trailing" id="mY1-8K-T3W"/>
+                                                    <constraint firstItem="Cqy-a9-VLC" firstAttribute="centerY" secondItem="Csj-Rf-u1l" secondAttribute="centerY" id="xgd-ut-3IV"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eKX-Vj-YCf">
+                                                <rect key="frame" x="0.0" y="147.5" width="366" height="32"/>
+                                                <subviews>
+                                                    <progressView contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aau-sy-kMa" customClass="ProgressView" customModule="Decred_Wallet" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="366" height="8"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="8" id="F0g-gx-ntR"/>
+                                                        </constraints>
+                                                        <color key="trackTintColor" red="0.95294117647058818" green="0.96078431372549022" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </progressView>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="aau-sy-kMa" secondAttribute="bottom" constant="24" id="IbV-tW-vNU"/>
+                                                    <constraint firstItem="aau-sy-kMa" firstAttribute="leading" secondItem="eKX-Vj-YCf" secondAttribute="leading" id="ZAj-YJ-cop"/>
+                                                    <constraint firstItem="aau-sy-kMa" firstAttribute="top" secondItem="eKX-Vj-YCf" secondAttribute="top" id="mDV-yB-fOG"/>
+                                                    <constraint firstAttribute="trailing" secondItem="aau-sy-kMa" secondAttribute="trailing" id="qj7-E6-4UI"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4NJ-Il-VAc">
+                                                <rect key="frame" x="0.0" y="180.5" width="366" height="64"/>
+                                                <subviews>
+                                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="05g-JX-ZBu">
+                                                        <rect key="frame" x="-8" y="0.0" width="79" height="40"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="79" id="L6K-9T-VMW"/>
+                                                            <constraint firstAttribute="height" constant="40" id="ZwN-tw-69N"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                                        <state key="normal" title="Back"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="back"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="onBack:" destination="SKa-iY-3vv" eventType="touchUpInside" id="dqh-Pu-H7D"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hE5-Xg-wZu">
+                                                        <rect key="frame" x="213" y="0.0" width="79" height="40"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="79" id="vgu-tU-bpZ"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                                        <state key="normal" title="Cancel"/>
+                                                        <connections>
+                                                            <action selector="onCancelButtonTapped:" destination="SKa-iY-3vv" eventType="touchUpInside" id="Uoo-pY-Xi8"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Irb-id-mc4" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
+                                                        <rect key="frame" x="300" y="0.0" width="66" height="40"/>
+                                                        <color key="backgroundColor" red="0.77000000000000002" green="0.80000000000000004" blue="0.81999999999999995" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="40" id="3eo-1S-fFG"/>
+                                                            <constraint firstAttribute="width" constant="66" id="PRB-Jt-Zcy"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="16"/>
+                                                        <state key="normal" title="Create">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="disabledBackgroundColor">
+                                                                <color key="value" red="0.76862745098039209" green="0.79607843137254897" blue="0.82352941176470584" alpha="1" colorSpace="calibratedRGB"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                <real key="value" value="7"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="create"/>
+                                                            <userDefinedRuntimeAttribute type="color" keyPath="enabledBackgroundColor">
+                                                                <color key="value" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                             </userDefinedRuntimeAttribute>
                                                         </userDefinedRuntimeAttributes>
-                                                    </collectionViewCell>
-                                                </cells>
-                                                <connections>
-                                                    <outlet property="dataSource" destination="SKa-iY-3vv" id="da2-Ch-WyQ"/>
-                                                    <outlet property="delegate" destination="SKa-iY-3vv" id="kTA-ks-KxE"/>
-                                                </connections>
-                                            </collectionView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter Spending PIN" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cqy-a9-VLC">
-                                                <rect key="frame" x="93" y="30.5" width="141.5" height="19"/>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
-                                                <color key="textColor" red="0.53725490196078429" green="0.59215686274509804" blue="0.6470588235294118" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
-                                                </userDefinedRuntimeAttributes>
-                                            </label>
-                                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="16" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TuL-zv-aYr">
-                                                <rect key="frame" x="315" y="33" width="12" height="14"/>
+                                                        <connections>
+                                                            <action selector="onSubmit:" destination="SKa-iY-3vv" eventType="touchUpInside" id="2lr-60-Ru1"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="12" id="zJg-qR-fQV"/>
+                                                    <constraint firstItem="05g-JX-ZBu" firstAttribute="leading" secondItem="4NJ-Il-VAc" secondAttribute="leading" constant="-8" id="2xA-d2-WBh"/>
+                                                    <constraint firstItem="05g-JX-ZBu" firstAttribute="centerY" secondItem="Irb-id-mc4" secondAttribute="centerY" id="CYQ-cc-mpf"/>
+                                                    <constraint firstItem="hE5-Xg-wZu" firstAttribute="height" secondItem="Irb-id-mc4" secondAttribute="height" id="JjC-QX-bfO"/>
+                                                    <constraint firstItem="hE5-Xg-wZu" firstAttribute="centerY" secondItem="Irb-id-mc4" secondAttribute="centerY" id="PnH-6c-huV"/>
+                                                    <constraint firstItem="Irb-id-mc4" firstAttribute="top" secondItem="4NJ-Il-VAc" secondAttribute="top" id="TfN-YJ-78M"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Irb-id-mc4" secondAttribute="trailing" id="V2A-AI-w49"/>
+                                                    <constraint firstAttribute="bottom" secondItem="Irb-id-mc4" secondAttribute="bottom" constant="24" id="rNJ-Lt-252"/>
+                                                    <constraint firstItem="Irb-id-mc4" firstAttribute="leading" secondItem="hE5-Xg-wZu" secondAttribute="trailing" constant="8" id="wWV-Do-Uwd"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
-                                                <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wrong startup PIN. Please try again." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Tx-gJ-gPY">
-                                                <rect key="frame" x="72.5" y="64" width="194.5" height="14"/>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
-                                                <color key="textColor" red="0.92941176470588238" green="0.42745098039215684" blue="0.27843137254901962" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="enterPIN"/>
-                                                </userDefinedRuntimeAttributes>
-                                            </label>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="Z10-H9-p32" secondAttribute="bottom" constant="32" id="3Gz-yl-ZPD"/>
-                                            <constraint firstItem="Cqy-a9-VLC" firstAttribute="centerX" secondItem="Csj-Rf-u1l" secondAttribute="centerX" id="Du2-iZ-UhQ"/>
-                                            <constraint firstItem="7Tx-gJ-gPY" firstAttribute="top" secondItem="Z10-H9-p32" secondAttribute="bottom" constant="16" id="PKc-6n-gIe"/>
-                                            <constraint firstItem="Z10-H9-p32" firstAttribute="top" secondItem="Csj-Rf-u1l" secondAttribute="top" constant="32" id="dXK-di-cwS"/>
-                                            <constraint firstItem="TuL-zv-aYr" firstAttribute="centerY" secondItem="Z10-H9-p32" secondAttribute="centerY" id="eWE-KB-yKv"/>
-                                            <constraint firstItem="TuL-zv-aYr" firstAttribute="leading" secondItem="Z10-H9-p32" secondAttribute="trailing" constant="24" id="eua-Lg-T8c"/>
-                                            <constraint firstItem="7Tx-gJ-gPY" firstAttribute="centerX" secondItem="Z10-H9-p32" secondAttribute="centerX" id="iMt-C1-TRQ"/>
-                                            <constraint firstItem="Z10-H9-p32" firstAttribute="leading" secondItem="Csj-Rf-u1l" secondAttribute="leading" constant="48" id="j2k-eM-75d"/>
-                                            <constraint firstAttribute="trailing" secondItem="TuL-zv-aYr" secondAttribute="trailing" id="mY1-8K-T3W"/>
-                                            <constraint firstItem="Cqy-a9-VLC" firstAttribute="centerY" secondItem="Csj-Rf-u1l" secondAttribute="centerY" id="xgd-ut-3IV"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eKX-Vj-YCf">
-                                        <rect key="frame" x="0.0" y="155.5" width="327" height="8"/>
-                                        <subviews>
-                                            <progressView contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aau-sy-kMa" customClass="ProgressView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="327" height="8"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="8" id="F0g-gx-ntR"/>
-                                                </constraints>
-                                                <color key="trackTintColor" red="0.95294117647058818" green="0.96078431372549022" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </progressView>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="aau-sy-kMa" secondAttribute="bottom" id="4fF-6f-L9s"/>
-                                            <constraint firstItem="aau-sy-kMa" firstAttribute="leading" secondItem="eKX-Vj-YCf" secondAttribute="leading" id="ZAj-YJ-cop"/>
-                                            <constraint firstAttribute="height" constant="8" id="hQO-I1-9aX"/>
-                                            <constraint firstItem="aau-sy-kMa" firstAttribute="top" secondItem="eKX-Vj-YCf" secondAttribute="top" id="mDV-yB-fOG"/>
-                                            <constraint firstAttribute="trailing" secondItem="aau-sy-kMa" secondAttribute="trailing" id="qj7-E6-4UI"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4NJ-Il-VAc">
-                                        <rect key="frame" x="0.0" y="164.5" width="327" height="88"/>
-                                        <subviews>
-                                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="05g-JX-ZBu">
-                                                <rect key="frame" x="-8" y="24" width="79" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="79" id="L6K-9T-VMW"/>
-                                                    <constraint firstAttribute="height" constant="40" id="ZwN-tw-69N"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="17"/>
-                                                <state key="normal" title="Back"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="back"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="onBack:" destination="SKa-iY-3vv" eventType="touchUpInside" id="dqh-Pu-H7D"/>
-                                                </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hE5-Xg-wZu">
-                                                <rect key="frame" x="174" y="24" width="79" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="KXs-Hw-JLO"/>
-                                                    <constraint firstAttribute="width" constant="79" id="vgu-tU-bpZ"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-SemiBold" family="Source Sans Pro" pointSize="17"/>
-                                                <state key="normal" title="Cancel"/>
-                                                <connections>
-                                                    <action selector="onCancelButtonTapped:" destination="SKa-iY-3vv" eventType="touchUpInside" id="Uoo-pY-Xi8"/>
-                                                </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Irb-id-mc4" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="261" y="24" width="66" height="40"/>
-                                                <color key="backgroundColor" red="0.77000000000000002" green="0.80000000000000004" blue="0.81999999999999995" alpha="1" colorSpace="calibratedRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="3eo-1S-fFG"/>
-                                                    <constraint firstAttribute="width" constant="66" id="PRB-Jt-Zcy"/>
-                                                </constraints>
-                                                <state key="normal" title="Create">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </state>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="color" keyPath="disabledBackgroundColor">
-                                                        <color key="value" red="0.76862745098039209" green="0.79607843137254897" blue="0.82352941176470584" alpha="1" colorSpace="calibratedRGB"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                        <real key="value" value="7"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="create"/>
-                                                    <userDefinedRuntimeAttribute type="color" keyPath="enabledBackgroundColor">
-                                                        <color key="value" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="onSubmit:" destination="SKa-iY-3vv" eventType="touchUpInside" id="2lr-60-Ru1"/>
-                                                </connections>
-                                            </button>
-                                        </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstItem="05g-JX-ZBu" firstAttribute="leading" secondItem="4NJ-Il-VAc" secondAttribute="leading" constant="-8" id="2xA-d2-WBh"/>
-                                            <constraint firstItem="05g-JX-ZBu" firstAttribute="centerY" secondItem="Irb-id-mc4" secondAttribute="centerY" id="CYQ-cc-mpf"/>
-                                            <constraint firstItem="hE5-Xg-wZu" firstAttribute="centerY" secondItem="Irb-id-mc4" secondAttribute="centerY" id="PnH-6c-huV"/>
-                                            <constraint firstItem="Irb-id-mc4" firstAttribute="top" secondItem="4NJ-Il-VAc" secondAttribute="top" constant="24" id="TfN-YJ-78M"/>
-                                            <constraint firstAttribute="trailing" secondItem="Irb-id-mc4" secondAttribute="trailing" id="V2A-AI-w49"/>
-                                            <constraint firstAttribute="bottom" secondItem="Irb-id-mc4" secondAttribute="bottom" constant="24" id="rNJ-Lt-252"/>
-                                            <constraint firstItem="Irb-id-mc4" firstAttribute="leading" secondItem="hE5-Xg-wZu" secondAttribute="trailing" constant="8" id="wWV-Do-Uwd"/>
-                                        </constraints>
-                                    </view>
+                                    </stackView>
                                 </subviews>
-                            </stackView>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="lgN-j6-puv" firstAttribute="leading" secondItem="fa7-1r-DRV" secondAttribute="leading" constant="24" id="2aY-xf-w1y"/>
+                                    <constraint firstAttribute="trailing" secondItem="lgN-j6-puv" secondAttribute="trailing" constant="24" id="Y8I-fP-8o2"/>
+                                    <constraint firstItem="lgN-j6-puv" firstAttribute="top" secondItem="fa7-1r-DRV" secondAttribute="top" id="feS-2j-GcM"/>
+                                    <constraint firstAttribute="bottom" secondItem="lgN-j6-puv" secondAttribute="bottom" id="ztC-IF-FVV"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="14"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.maskedCorners">
+                                        <integer key="value" value="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="lgN-j6-puv" firstAttribute="leading" secondItem="hEG-La-4vV" secondAttribute="leading" constant="24" id="OB6-kx-tBb"/>
-                            <constraint firstItem="lgN-j6-puv" firstAttribute="top" secondItem="hEG-La-4vV" secondAttribute="top" id="P0i-hl-FJc"/>
-                            <constraint firstItem="lgN-j6-puv" firstAttribute="trailing" secondItem="hEG-La-4vV" secondAttribute="trailing" constant="-24" id="U0s-BM-5ma"/>
+                            <constraint firstItem="fa7-1r-DRV" firstAttribute="leading" secondItem="hEG-La-4vV" secondAttribute="leading" id="1z7-8U-09p"/>
+                            <constraint firstAttribute="bottom" secondItem="fa7-1r-DRV" secondAttribute="bottom" id="LS3-bj-E5a"/>
+                            <constraint firstItem="hEG-La-4vV" firstAttribute="trailing" secondItem="fa7-1r-DRV" secondAttribute="trailing" id="Owe-V2-FTF"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="hEG-La-4vV"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Item 2" id="2n3-H2-ODn"/>
+                    <nil key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="btnBack" destination="05g-JX-ZBu" id="Qqr-IK-ilX"/>
                         <outlet property="btnCancel" destination="hE5-Xg-wZu" id="mtW-Su-mls"/>
                         <outlet property="btnSubmit" destination="Irb-id-mc4" id="dcQ-6q-Tm2"/>
+                        <outlet property="containerView" destination="fa7-1r-DRV" id="lbM-aj-nwi"/>
                         <outlet property="enterPinLabel" destination="Cqy-a9-VLC" id="kzv-ms-yVX"/>
                         <outlet property="errorLabel" destination="7Tx-gJ-gPY" id="adC-FS-QKJ"/>
                         <outlet property="headerLabel" destination="LFW-Ta-LtS" id="ag6-2f-dyU"/>
@@ -554,11 +635,12 @@
                         <outlet property="pinCollectionViewHeightContraint" destination="voX-Vs-U5n" id="arY-pa-Nj0"/>
                         <outlet property="pinCount" destination="TuL-zv-aYr" id="hkN-eJ-iui"/>
                         <outlet property="prgsPinStrength" destination="aau-sy-kMa" id="Wmi-PX-KW1"/>
+                        <outlet property="stackViewBottomConstraint" destination="ztC-IF-FVV" id="G1v-GN-vSF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ubd-bg-fVZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6268" y="-110.09852216748769"/>
+            <point key="canvasLocation" x="6267" y="-254"/>
         </scene>
     </scenes>
 </document>

--- a/Decred Wallet/Features/Security/SecurityViewController.swift
+++ b/Decred Wallet/Features/Security/SecurityViewController.swift
@@ -25,6 +25,18 @@ class SecurityViewController: SecurityBaseViewController {
     @IBOutlet weak var securityPromptLabel: UILabel!
     @IBOutlet weak var btnPin: UIButton!
     @IBOutlet weak var btnPassword: UIButton!
+    @IBOutlet weak var containerViewHeightConstraint: NSLayoutConstraint!
+
+    private func updateContainerViewHeight(height: CGFloat) {
+        DispatchQueue.main.async {
+            if self.containerViewHeightConstraint.constant != height {
+                UIView.animate(withDuration: 0.1) {
+                    self.containerViewHeightConstraint.constant = height
+                    self.view.layoutIfNeeded()
+                }
+            }
+        }
+    }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "loadTabBarController" {
@@ -35,6 +47,14 @@ class SecurityViewController: SecurityBaseViewController {
             passwordTabVC?.securityFor = self.securityFor
             passwordTabVC?.requestConfirmation = true
             passwordTabVC?.showCancelButton = true
+            passwordTabVC?.onViewHeightChanged = updateContainerViewHeight
+            passwordTabVC?.onLoadingStatusChanged = { (loading: Bool) in
+                self.btnPin?.isEnabled = !loading
+                self.btnPassword?.isEnabled = !loading
+                self.btnPassword.addBorder(atPosition: .bottom,
+                                           color: loading ? UIColor.appColors.darkGray: UIColor.appColors.lightBlue,
+                                           thickness: 2)
+            }
             passwordTabVC?.onUserEnteredSecurityCode = { (code: String, completionDelegate: SecurityRequestCompletionDelegate?) in
                 self.onUserEnteredPinOrPassword?(code, SecurityViewController.SECURITY_TYPE_PASSWORD, completionDelegate)
             }
@@ -43,6 +63,14 @@ class SecurityViewController: SecurityBaseViewController {
             pinTabVC?.securityFor = self.securityFor
             pinTabVC?.requestConfirmation = true
             pinTabVC?.showCancelButton = true
+            pinTabVC?.onViewHeightChanged = updateContainerViewHeight
+            pinTabVC?.onLoadingStatusChanged = { (loading: Bool) in
+                self.btnPin?.isEnabled = !loading
+                self.btnPassword?.isEnabled = !loading
+                self.btnPin.addBorder(atPosition: .bottom,
+                                           color: loading ? UIColor.appColors.darkGray: UIColor.appColors.lightBlue,
+                                           thickness: 2)
+            }
             pinTabVC?.onUserEnteredSecurityCode = { (code: String, completionDelegate: SecurityRequestCompletionDelegate?) in
                 self.onUserEnteredPinOrPassword?(code, SecurityViewController.SECURITY_TYPE_PIN, completionDelegate)
             }
@@ -76,6 +104,7 @@ class SecurityViewController: SecurityBaseViewController {
         // add border below password tab and remove border below PIN tab
         btnPassword.addBorder(atPosition: .bottom, color: UIColor.appColors.lightBlue, thickness: 2)
         btnPin.removeBorders(atPositions: .bottom)
+        btnPin.addBorder(atPosition: .bottom, color: UIColor.appColors.gray, thickness: 1)
 
         // set active and inactive text colors
         btnPassword.setTitleColor(UIColor.appColors.lightBlue, for: .normal)
@@ -90,6 +119,7 @@ class SecurityViewController: SecurityBaseViewController {
         // add border below PIN tab and remove border below PIN tab
         btnPin.addBorder(atPosition: .bottom, color: UIColor.appColors.lightBlue, thickness: 2)
         btnPassword.removeBorders(atPositions: .bottom)
+        btnPassword.addBorder(atPosition: .bottom, color: UIColor.appColors.gray, thickness: 1)
 
         // set active and inactive text colors
         btnPin.setTitleColor(UIColor.appColors.lightBlue, for: .normal)


### PR DESCRIPTION
This PR extends #551 and adjust visually all PIN/password request/setup views regards to the mockup.

<img width="414" alt="Screenshot 2020-01-13 at 20 58 16" src="https://user-images.githubusercontent.com/794430/72287871-1f5daf00-3648-11ea-866c-e611e6c4e0e0.png">
<img width="414" alt="Screenshot 2020-01-13 at 20 58 45" src="https://user-images.githubusercontent.com/794430/72287878-25539000-3648-11ea-8faa-b5db36307b68.png">
<img width="414" alt="Screenshot 2020-01-13 at 20 57 11" src="https://user-images.githubusercontent.com/794430/72287907-300e2500-3648-11ea-9e4e-0d1b9727c900.png">
<img width="414" alt="Screenshot 2020-01-13 at 20 56 58" src="https://user-images.githubusercontent.com/794430/72287923-37cdc980-3648-11ea-85bb-374b2f9c875e.png">
