### PR TITLE
remove obsolete check from sync -> rescan progress handler

### DIFF
--- a/Decred Wallet/Features/Overview/SyncDetailsComponent.swift
+++ b/Decred Wallet/Features/Overview/SyncDetailsComponent.swift
@@ -45,11 +45,6 @@ class SyncDetailsComponent: UIView {
         super.init(coder: aDecoder)
     }
     
-//    convenience init() {
-//        self.init(frame: .zero)
-//
-//    }
-    
     // Set component properties and their AutoLayout Constraints relative to each other
     func setupComponents() {
         // setup container holding details
@@ -162,10 +157,10 @@ class SyncDetailsComponent: UIView {
         NSLayoutConstraint.activate([
             
             // separator contraints
-                       self.separator.heightAnchor.constraint(equalToConstant: 0.5),
-                       self.separator.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
-                       self.separator.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
-                       self.separator.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
+           self.separator.heightAnchor.constraint(equalToConstant: 0.5),
+           self.separator.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
+           self.separator.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
+           self.separator.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
             
             // Current sync step (1,2 or 3)
             self.stepsLabel.heightAnchor.constraint(equalToConstant: 16),

--- a/Decred Wallet/Features/Wallet Utils/Syncer.swift
+++ b/Decred Wallet/Features/Wallet Utils/Syncer.swift
@@ -285,7 +285,8 @@ extension Syncer: DcrlibwalletSyncProgressListenerProtocol {
         self.currentSyncOp = .FetchingHeaders
         self.currentSyncOpProgress = headersFetchProgress
         self.forEachSyncListener({ syncListener in syncListener.onHeadersFetchProgress(headersFetchProgress!) })
-        if let headers = headersFetchProgress, let progress = headers.generalSyncProgress {
+        
+        if let progress = headersFetchProgress?.generalSyncProgress {
             fireLocalBackgroundSyncNotificationIfInBackground(with: progress)
         }
     }
@@ -298,21 +299,22 @@ extension Syncer: DcrlibwalletSyncProgressListenerProtocol {
         self.currentSyncOp = .DiscoveringAddresses
         self.currentSyncOpProgress = addressDiscoveryProgress
         self.forEachSyncListener({ syncListener in syncListener.onAddressDiscoveryProgress(addressDiscoveryProgress!) })
-        if let headers = addressDiscoveryProgress, let progress = headers.generalSyncProgress {
+        
+        if let progress = addressDiscoveryProgress?.generalSyncProgress {
             fireLocalBackgroundSyncNotificationIfInBackground(with: progress)
         }
     }
     
     func onHeadersRescanProgress(_ headersRescanProgress: DcrlibwalletHeadersRescanProgressReport?) {
-        self.currentSyncOp = .RescanningHeaders
-        self.currentSyncOpProgress = headersRescanProgress
-        
         if !self.syncCompletedCanceledOrErrored {
             self.restartSyncIfItStalls()
         }
         
+        self.currentSyncOp = .RescanningHeaders
+        self.currentSyncOpProgress = headersRescanProgress
         self.forEachSyncListener({ syncListener in syncListener.onHeadersRescanProgress(headersRescanProgress!) })
-        if let headers = headersRescanProgress, let progress = headers.generalSyncProgress {
+        
+        if let progress = headersRescanProgress?.generalSyncProgress {
             fireLocalBackgroundSyncNotificationIfInBackground(with: progress)
         }
     }

--- a/Decred Wallet/Features/Wallet Utils/Syncer.swift
+++ b/Decred Wallet/Features/Wallet Utils/Syncer.swift
@@ -304,15 +304,11 @@ extension Syncer: DcrlibwalletSyncProgressListenerProtocol {
     }
     
     func onHeadersRescanProgress(_ headersRescanProgress: DcrlibwalletHeadersRescanProgressReport?) {
-        // Do not set current sync op for blocks rescan.
-        // Ideally, blocks rescan should notify a different callback than sync - rescan stage.
-        if !AppDelegate.walletLoader.multiWallet.isRescanning() {
-            self.currentSyncOp = .RescanningHeaders
-            self.currentSyncOpProgress = headersRescanProgress
-            
-            if !self.syncCompletedCanceledOrErrored {
-                self.restartSyncIfItStalls()
-            }
+        self.currentSyncOp = .RescanningHeaders
+        self.currentSyncOpProgress = headersRescanProgress
+        
+        if !self.syncCompletedCanceledOrErrored {
+            self.restartSyncIfItStalls()
         }
         
         self.forEachSyncListener({ syncListener in syncListener.onHeadersRescanProgress(headersRescanProgress!) })


### PR DESCRIPTION
The check done in the rescan progress handler to determine whether the ongoing rescan is user-triggered or part of the startup sync operation causes the rescan operation to stall because of a dcrlibwallet bug.

User-triggered blocks rescan now notifies on a different callback rather than the sync - rescan stage progress callback. Thus, the problematic check (noted above) is now unnecessary and is removed.