### PR TITLE
wallet loader improvements

### DIFF
--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -116,7 +116,7 @@ extension DcrlibwalletWallet {
     }
     
     func transactionHistory(offset: Int32, count: Int32 = 0, filter: Int32 = DcrlibwalletTxFilterAll) -> [Transaction]? {
-        guard let wallet = WalletLoader.shared.wallet else {
+        guard let wallet = WalletLoader.shared.firstWallet else {
             return nil
         }
         

--- a/Decred Wallet/Features/App Launch/StartScreenViewController.swift
+++ b/Decred Wallet/Features/App Launch/StartScreenViewController.swift
@@ -59,7 +59,7 @@ class StartScreenViewController: UIViewController {
     }
 
     func loadMainScreen() {
-        if !WalletLoader.shared.initialized {
+        if !WalletLoader.shared.isInitialized {
             // there was an error initializing multiwallet
             return
         }

--- a/Decred Wallet/Features/History/TransactionHistoryViewController.swift
+++ b/Decred Wallet/Features/History/TransactionHistoryViewController.swift
@@ -61,7 +61,7 @@ class TransactionHistoryViewController: UIViewController {
         self.allTransactions.removeAll()
         self.refreshControl.showLoader(in: self.transactionsTableView)
         
-        guard let txs = WalletLoader.shared.wallet?.transactionHistory(offset: 0), !txs.isEmpty else {
+        guard let txs = WalletLoader.shared.firstWallet?.transactionHistory(offset: 0), !txs.isEmpty else {
             self.transactionsTableView.backgroundView = self.noTxsLabel
             self.transactionsTableView.separatorStyle = .none
             self.refreshControl.endRefreshing()

--- a/Decred Wallet/Features/History/TransactionTableViewCell.swift
+++ b/Decred Wallet/Features/History/TransactionTableViewCell.swift
@@ -28,7 +28,7 @@ class TransactionTableViewCell: UITableViewCell {
         if let transaction = data as? Transaction {
             var confirmations: Int32 = 0
             if transaction.blockHeight != -1 {
-                confirmations = WalletLoader.shared.wallet!.getBestBlock() - Int32(transaction.blockHeight) + 1
+                confirmations = WalletLoader.shared.firstWallet!.getBestBlock() - Int32(transaction.blockHeight) + 1
             }
             let Date2 = NSDate.init(timeIntervalSince1970: TimeInterval(transaction.timestamp) )
                       let dateformater = DateFormatter()

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -98,7 +98,7 @@ class OverviewViewController: UIViewController {
         self.parentScrollView.delegate = self
         
         self.checkWhetherToPromptForSeedBackup()
-        WalletLoader.shared.walletSeedBackedUp.subscribe(with: self) { walletID in
+        WalletLoader.WalletSeedBackedUp.subscribe(with: self) { walletID in
             print("Seed backed up for wallet with ID", walletID)
             self.checkWhetherToPromptForSeedBackup()
         }
@@ -119,7 +119,7 @@ class OverviewViewController: UIViewController {
     // todo ensure this is always called from the main thread!
     func updateMultiWalletBalance() {
         // todo should use multiwallet balance!
-        let totalWalletAmount = WalletLoader.shared.wallet?.totalWalletBalance() ?? 0
+        let totalWalletAmount = WalletLoader.shared.firstWallet?.totalWalletBalance() ?? 0
         let totalAmountRoundedOff = (Decimal(totalWalletAmount) as NSDecimalNumber).round(8)
         self.balanceLabel.attributedText = Utils.getAttributedString(str: "\(totalAmountRoundedOff)", siz: 17.0, TexthexColor: UIColor.appColors.darkBlue)
     }
@@ -127,7 +127,7 @@ class OverviewViewController: UIViewController {
     func updateRecentActivity() {
         // Fetch 3 most recent transactions
         // todo this should be a multiwallet fetch rather than a wallet fetch!
-        guard let transactions = WalletLoader.shared.wallet?.transactionHistory(offset: 0, count: 3) else {
+        guard let transactions = WalletLoader.shared.firstWallet?.transactionHistory(offset: 0, count: 3) else {
             self.recentTransactionsTableView.isHidden = true
             self.showAllTransactionsButton.isHidden = true
             self.noTransactionsLabelView.superview?.isHidden = false

--- a/Decred Wallet/Features/SecurityMenu/SecurityMenuViewController.swift
+++ b/Decred Wallet/Features/SecurityMenu/SecurityMenuViewController.swift
@@ -40,7 +40,7 @@ class SecurityMenuViewController: UIViewController,UITextFieldDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        wallet = WalletLoader.shared.wallet
+        wallet = WalletLoader.shared.firstWallet
         self.address.delegate = self
         self.signature.delegate = self
         self.message.delegate = self

--- a/Decred Wallet/Features/Seed Backup/SeedBackupVerifyViewController.swift
+++ b/Decred Wallet/Features/Seed Backup/SeedBackupVerifyViewController.swift
@@ -69,10 +69,10 @@ class SeedBackupVerifyViewController: UIViewController {
         let userEnteredSeed = selectedWords.joined(separator: " ")
 
         do {
-            try WalletLoader.shared.multiWallet.verifySeed(forWallet: WalletLoader.shared.wallet!.id_,
+            try WalletLoader.shared.multiWallet.verifySeed(forWallet: WalletLoader.shared.firstWallet!.id_,
                                                            seedMnemonic: userEnteredSeed)
             
-            WalletLoader.shared.walletSeedBackedUp => WalletLoader.shared.wallet!.id_
+            WalletLoader.WalletSeedBackedUp => WalletLoader.shared.firstWallet!.id_
             self.performSegue(withIdentifier: "toSeedBackupSuccess", sender: nil)
         } catch {
             self.groupedSeedWordsTableView?.isUserInteractionEnabled = true

--- a/Decred Wallet/Features/Seed Backup/SeedWordsDisplayViewController.swift
+++ b/Decred Wallet/Features/Seed Backup/SeedWordsDisplayViewController.swift
@@ -18,7 +18,7 @@ class SeedWordsDisplayViewController: UIViewController, UITableViewDataSource {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.seed = WalletLoader.shared.wallet!.seed
+        self.seed = WalletLoader.shared.firstWallet!.seed
         arrWords = (self.seed.components(separatedBy: " "))
 
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) { [weak self] in

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -54,7 +54,7 @@ class SendViewController: UIViewController {
             return self.destinationAccountDropdown.selectedItemIndex >= 0
         }
         let destinationAddress = self.destinationAddressTextField.text ?? ""
-        return WalletLoader.shared.wallet!.isAddressValid(destinationAddress)
+        return WalletLoader.shared.firstWallet!.isAddressValid(destinationAddress)
     }
     
     var isValidAmount: Bool {
@@ -198,7 +198,7 @@ class SendViewController: UIViewController {
     }
     
     func setupAccountDropdowns() {
-        let walletAccounts = WalletLoader.shared.wallet!.walletAccounts(confirmations: self.requiredConfirmations)
+        let walletAccounts = WalletLoader.shared.firstWallet!.walletAccounts(confirmations: self.requiredConfirmations)
             .filter({ !$0.isHidden && $0.number != INT_MAX }) // remove hidden wallets from array
         self.walletAccounts = walletAccounts
         
@@ -284,7 +284,7 @@ class SendViewController: UIViewController {
         }
         
         let destinationAddress = self.getDestinationAddress(isSendAttempt: false)
-        let wallet = WalletLoader.shared.wallet!
+        let wallet = WalletLoader.shared.firstWallet!
         
         do {
             let newTx = wallet.newUnsignedTx(sourceAccount.number, requiredConfirmations: self.requiredConfirmations)
@@ -381,7 +381,7 @@ class SendViewController: UIViewController {
             let sendAmountAtom = DcrlibwalletAmountAtom(sendAmountDcr)
             let sourceAccountNumber = self.walletAccounts[self.sourceAccountDropdown.selectedItemIndex].number
             
-            let newTx = WalletLoader.shared.wallet!.newUnsignedTx(sourceAccountNumber,
+            let newTx = WalletLoader.shared.firstWallet!.newUnsignedTx(sourceAccountNumber,
                                                                        requiredConfirmations: self.requiredConfirmations)
             newTx?.addSendDestination(destinationAddress,
                                       atomAmount: sendAmountAtom,
@@ -414,7 +414,7 @@ class SendViewController: UIViewController {
         let progressHud = Utils.showProgressHud(withText: LocalizedStrings.sendingTransaction)
         DispatchQueue.global(qos: .userInitiated).async {[unowned self] in
             do {
-                let newTx = WalletLoader.shared.wallet!.newUnsignedTx(sourceAccountNumber,
+                let newTx = WalletLoader.shared.firstWallet!.newUnsignedTx(sourceAccountNumber,
                                                                            requiredConfirmations: self.requiredConfirmations)
                 newTx?.addSendDestination(destinationAddress,
                                           atomAmount: sendAmountAtom,
@@ -538,7 +538,7 @@ extension SendViewController {
     
     @objc func addressTextFieldChanged() {
         let destinationAddress = self.destinationAddressTextField.text ?? ""
-        let addressValid = WalletLoader.shared.wallet!.isAddressValid(destinationAddress)
+        let addressValid = WalletLoader.shared.firstWallet!.isAddressValid(destinationAddress)
         
         self.toggleSendButtonState(addressValid: addressValid, amountValid: self.isValidAmount)
         self.scanQrCodeButton.isHidden = destinationAddress != ""
@@ -553,7 +553,7 @@ extension SendViewController {
     
     func checkClipboardForValidAddress() {
         let canShowPasteButton = (self.destinationAddressTextField.text ?? "") == "" &&
-            WalletLoader.shared.wallet!.isAddressValid(UIPasteboard.general.string)
+            WalletLoader.shared.firstWallet!.isAddressValid(UIPasteboard.general.string)
         self.pasteAddressButton.isHidden = !canShowPasteButton
     }
     
@@ -586,7 +586,7 @@ extension SendViewController {
         }
         
         // Also ensure that destinationAddressTextField.text is a valid address.
-        guard WalletLoader.shared.wallet!.isAddressValid(destinationAddress) else {
+        guard WalletLoader.shared.firstWallet!.isAddressValid(destinationAddress) else {
             if displayErrorOnUI {
                 self.destinationErrorLabel.text = LocalizedStrings.invalidDestAddr
             }
@@ -598,7 +598,7 @@ extension SendViewController {
     
     func generateAddress(from account: DcrlibwalletAccount) -> String? {
         var generateAddressError: NSError?
-        let destinationAddress = WalletLoader.shared.wallet!.currentAddress(account.number, error: &generateAddressError)
+        let destinationAddress = WalletLoader.shared.firstWallet!.currentAddress(account.number, error: &generateAddressError)
         if generateAddressError != nil {
             print("send page -> generate address for destination account error: \(generateAddressError!.localizedDescription)")
             return nil

--- a/Decred Wallet/Features/Settings/SettingsController.swift
+++ b/Decred Wallet/Features/Settings/SettingsController.swift
@@ -161,7 +161,7 @@ class SettingsController: UITableViewController  {
     }
     
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        let isWalletOpen = WalletLoader.shared.wallet?.walletOpened() ?? false
+        let isWalletOpen = WalletLoader.shared.firstWallet?.walletOpened() ?? false
         
         if indexPath.section == 0 {
             switch indexPath.row {
@@ -240,7 +240,7 @@ class SettingsController: UITableViewController  {
         }
         
         do {
-            try WalletLoader.shared.multiWallet.rescanBlocks(WalletLoader.shared.wallet!.id_)
+            try WalletLoader.shared.multiWallet.rescanBlocks(WalletLoader.shared.firstWallet!.id_)
             self.displayToast(LocalizedStrings.scanInProgress)
         } catch let error {
             var errorMessage = error.localizedDescription
@@ -271,7 +271,7 @@ class SettingsController: UITableViewController  {
         let progressHud = Utils.showProgressHud(withText: LocalizedStrings.deletingWallet)
         DispatchQueue.global(qos: .background).async {
             do {
-                try WalletLoader.shared.multiWallet.delete(WalletLoader.shared.wallet!.id_,
+                try WalletLoader.shared.multiWallet.delete(WalletLoader.shared.firstWallet!.id_,
                                                            privPass: spendingPinOrPassword.utf8Bits)
                 DispatchQueue.main.async {
                     progressHud.dismiss()

--- a/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
+++ b/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
@@ -52,7 +52,7 @@ class TransactionDetailsViewController: UIViewController, SFSafariViewController
         if self.transaction == nil && self.transactionHash != nil {
             let txHash = Data(fromHexEncodedString: self.transactionHash!)!
             var getTxError: NSError?
-            let txJsonString = WalletLoader.shared.wallet?.getTransaction(txHash, error: &getTxError)
+            let txJsonString = WalletLoader.shared.firstWallet?.getTransaction(txHash, error: &getTxError)
             if getTxError != nil {
                 print("wallet.getTransaction error", getTxError!.localizedDescription)
             }
@@ -70,7 +70,7 @@ class TransactionDetailsViewController: UIViewController, SFSafariViewController
     fileprivate func prepareTransactionDetails() {
         var confirmations: Int32 = 0
         if self.transaction.blockHeight != -1 {
-            confirmations = WalletLoader.shared.wallet!.getBestBlock() - Int32(self.transaction.blockHeight) + 1
+            confirmations = WalletLoader.shared.firstWallet!.getBestBlock() - Int32(self.transaction.blockHeight) + 1
         }
         
         let isConfirmed = Settings.spendUnconfirmed || confirmations > 1

--- a/Decred Wallet/Features/Wallet Utils/SpendingPinOrPassword.swift
+++ b/Decred Wallet/Features/Wallet Utils/SpendingPinOrPassword.swift
@@ -33,7 +33,7 @@ struct SpendingPinOrPassword {
             do {
                 let passphraseType = newCodeType == .password ? DcrlibwalletPassphraseTypePass : DcrlibwalletPassphraseTypePin
                 
-                try WalletLoader.shared.multiWallet.changePrivatePassphrase(forWallet: WalletLoader.shared.wallet!.id_,
+                try WalletLoader.shared.multiWallet.changePrivatePassphrase(forWallet: WalletLoader.shared.firstWallet!.id_,
                                                                             oldPrivatePassphrase: currentCode.utf8Bits,
                                                                             newPrivatePassphrase: newCode.utf8Bits,
                                                                             privatePassphraseType: passphraseType)

--- a/Decred Wallet/Utils/Utils.swift
+++ b/Decred Wallet/Utils/Utils.swift
@@ -78,7 +78,7 @@ struct Utils {
         let int64Pointer = UnsafeMutablePointer<Int64>.allocate(capacity: 64)
         do {
             
-            try WalletLoader.shared.wallet?.spendable(forAccount: account.number, requiredConfirmations: iRequireConfirm, ret0_: int64Pointer)
+            try WalletLoader.shared.firstWallet?.spendable(forAccount: account.number, requiredConfirmations: iRequireConfirm, ret0_: int64Pointer)
         } catch let error{
             print(error)
             return 0.0

--- a/Decred Wallet/view_controller/AccountViewController.swift
+++ b/Decred Wallet/view_controller/AccountViewController.swift
@@ -78,7 +78,7 @@ class AccountViewController: UIViewController, UITableViewDataSource, UITableVie
             this.accounts?.removeAll()
             this.accountHeaders.removeAll()
             
-            if let acc = WalletLoader.shared.wallet?.walletAccounts(confirmations: 0) {
+            if let acc = WalletLoader.shared.firstWallet?.walletAccounts(confirmations: 0) {
                 this.accounts = acc
                 this.accountHeaders = acc.map({ AccountHeader(entity: $0, color: nil) })
             }

--- a/Decred Wallet/view_controller/AddAcountViewController.swift
+++ b/Decred Wallet/view_controller/AddAcountViewController.swift
@@ -71,7 +71,7 @@ class AddAcountViewController: UIViewController {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 // pass nil pointer as we don't need the account number
-                try WalletLoader.shared.wallet?.nextAccount(accountName, privPass: passphrase, ret0_: nil)
+                try WalletLoader.shared.firstWallet?.nextAccount(accountName, privPass: passphrase, ret0_: nil)
                 DispatchQueue.main.async {
                     progressHud.dismiss()
                     completion?.securityCodeProcessed()

--- a/Decred Wallet/view_controller/ReceiveViewController.swift
+++ b/Decred Wallet/view_controller/ReceiveViewController.swift
@@ -34,7 +34,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     var myacc: DcrlibwalletAccount?
     var tapGesture = UITapGestureRecognizer()
     var oldAddress = ""
-    var wallet = WalletLoader.shared.wallet
+    var wallet = WalletLoader.shared.firstWallet
 
     private var selectedAccount = ""
 
@@ -108,7 +108,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     }
 
     private func checkSyncStatus() {
-        guard let wallet = WalletLoader.shared.wallet, (!wallet.isRestored || wallet.hasDiscoveredAccounts) else {
+        guard let wallet = WalletLoader.shared.firstWallet, (!wallet.isRestored || wallet.hasDiscoveredAccounts) else {
             contentStackView.isHidden = true
             syncInProgressLabel.isHidden = false
             return
@@ -142,7 +142,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     
     private func showFirstWalletAddressAndQRCode() {
         
-        if let acc = WalletLoader.shared.wallet?.walletAccounts(confirmations: 0) {
+        if let acc = WalletLoader.shared.firstWallet?.walletAccounts(confirmations: 0) {
             let accNames: [String] = (acc.map({ $0.name }))
             self.myacc = acc.first
             
@@ -158,7 +158,7 @@ class ReceiveViewController: UIViewController,UIDocumentInteractionControllerDel
     
     private func populateWalletDropdownMenu() {
 
-        if let acc = WalletLoader.shared.wallet?.walletAccounts(confirmations: 0) {
+        if let acc = WalletLoader.shared.firstWallet?.walletAccounts(confirmations: 0) {
            if let defaultAccount = acc.filter({ $0.isDefault}).first {
                 accountDropdown.setTitle(
                     defaultAccount.name,


### PR DESCRIPTION
- rename `WalletLoader.wallet` to `WalletLoader.firstWallet` to better highlight possible multiwallet presence in usage sites which would encourage refactoring where necessary to cater for all wallets rather than just one
- add `WalletLoader.wallets` helper property to access an array of all wallets in the app, sorted by id.

Requires https://github.com/raedahgroup/dcrlibwallet/pull/98.