### PR TITLE
Use dcrlibwallet config feature for user preferences

### DIFF
--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3635B81229FE5870052EB4D /* QRImageScanner.swift */; };
 		B36EFD362298617C002753B2 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36EFD352298617C002753B2 /* UIButton.swift */; };
 		B377DB0722A5663700BDF56F /* DeleteWalletConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */; };
+		B379BA6523E2A2F1002CA92E /* SingleToMultiWalletMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */; };
 		B3967B3D22A75BD400E14432 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3967B3C22A75BD400E14432 /* UITableView.swift */; };
 		B39BDC4D228F798300F3FB55 /* BuildConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39BDC4C228F798300F3FB55 /* BuildConfig.swift */; };
 		B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF8522936BFE00008A4E /* Reachability.swift */; };
@@ -180,6 +181,7 @@
 		B3635B81229FE5870052EB4D /* QRImageScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRImageScanner.swift; sourceTree = "<group>"; };
 		B36EFD352298617C002753B2 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
 		B377DB0622A5663700BDF56F /* DeleteWalletConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteWalletConfirmationViewController.swift; sourceTree = "<group>"; };
+		B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleToMultiWalletMigration.swift; sourceTree = "<group>"; };
 		B3967B3C22A75BD400E14432 /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
 		B39BDC4C228F798300F3FB55 /* BuildConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfig.swift; sourceTree = "<group>"; };
 		B3A3EF8522936BFE00008A4E /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 				B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */,
 				B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */,
 				B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */,
+				B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */,
 			);
 			path = "Wallet Utils";
 			sourceTree = "<group>";
@@ -972,6 +975,7 @@
 				B3B46AB3228F0F7D00A68EDD /* ConfirmSeedViewCell.swift in Sources */,
 				B3B46A88228F0F7D00A68EDD /* UIIMage.swift in Sources */,
 				B3B46A11228F0F2700A68EDD /* UITableViewExtension.swift in Sources */,
+				B379BA6523E2A2F1002CA92E /* SingleToMultiWalletMigration.swift in Sources */,
 				B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */,
 				B3B46A2E228F0F2700A68EDD /* MenuItem.swift in Sources */,
 				B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */,

--- a/Decred Wallet/Accounts/AccountHeader.swift
+++ b/Decred Wallet/Accounts/AccountHeader.swift
@@ -2,7 +2,7 @@
 //  AccountsData.swift
 //  Decred Wallet
 //
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,7 +28,8 @@ struct AccountHeader {
     }
     
     var isHidden: Bool {
-        return Settings.readValue(for: "\(Settings.Keys.HiddenWalletPrefix)\(self.number)")
+        // deprecated feature
+        return false
     }
 }
 

--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -81,15 +81,17 @@ extension DcrlibwalletBalance {
 
 extension DcrlibwalletAccount {
     func makeDefault() {
-        Settings.setValue(self.number, for: Settings.Keys.DefaultWallet)
+        // deprecated feature
     }
     
     var isDefault: Bool {
-        return Settings.readOptionalValue(for: Settings.Keys.DefaultWallet) == self.number
+        // deprecated feature
+        return false
     }
     
     var isHidden: Bool {
-        return Settings.readValue(for: "\(Settings.Keys.HiddenWalletPrefix)\(self.number)")
+        // deprecated feature
+        return false
     }
     
     var dcrTotalBalance: Double {
@@ -136,7 +138,7 @@ extension DcrlibwalletWallet {
         
         if transactions != nil {
             // Check if there are new transactions since last time wallet history was displayed.
-            let lastTxHash = Settings.readOptionalValue(for: Settings.Keys.LastTxHash) ?? ""
+            let lastTxHash = Settings.readStringValue(for: DcrlibwalletLastTxHashConfigKey)
             for i in 0..<transactions!.count {
                 if transactions![i].hash == lastTxHash {
                     // We've hit the last viewed tx. No need to animate this tx or futher txs.
@@ -146,7 +148,7 @@ extension DcrlibwalletWallet {
             }
             
             // Save hash for tx index 0 as last viewed tx hash.
-            Settings.setValue(transactions![0].hash, for: Settings.Keys.LastTxHash)
+            Settings.setStringValue(transactions![0].hash, for: DcrlibwalletLastTxHashConfigKey)
         }
         
         return transactions

--- a/Decred Wallet/Features/History/TransactionHistoryViewController.swift
+++ b/Decred Wallet/Features/History/TransactionHistoryViewController.swift
@@ -175,7 +175,7 @@ extension TransactionHistoryViewController: DcrlibwalletTxAndBlockNotificationLi
         self.allTransactions.insert(tx, at: 0)
         
         // Save hash for this tx as last viewed tx hash.
-        Settings.setValue(tx.hash, for: Settings.Keys.LastTxHash)
+        Settings.setStringValue(tx.hash, for: DcrlibwalletLastTxHashConfigKey)
         
         DispatchQueue.main.async {
             self.reloadTxsForCurrentFilter()

--- a/Decred Wallet/Features/Settings/CurrencyConversionOptionsViewController.swift
+++ b/Decred Wallet/Features/Settings/CurrencyConversionOptionsViewController.swift
@@ -2,11 +2,12 @@
 //  CurrencyConversionOptionsViewController.swift
 //  Decred Wallet
 //
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 import UIKit
+import Dcrlibwallet
 
 enum CurrencyConversionOption: String, CaseIterable {
     case None = "none"
@@ -45,7 +46,7 @@ class CurrencyConversionOptionsViewController: UITableViewController {
         tableView.cellForRow(at: indexPath as IndexPath)?.accessoryType = .checkmark
         
         let selectedOption = CurrencyConversionOption.allCases[indexPath.row]
-        Settings.setValue(selectedOption.rawValue, for: Settings.Keys.CurrencyConversionOption)
+        Settings.setStringValue(selectedOption.rawValue, for: DcrlibwalletCurrencyConversionConfigKey)
     }
     
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {

--- a/Decred Wallet/Features/Settings/NetworkModeTableViewController.swift
+++ b/Decred Wallet/Features/Settings/NetworkModeTableViewController.swift
@@ -2,11 +2,12 @@
 //  NetworkModeTableViewController.swift
 //  Decred Wallet
 //
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 import UIKit
+import Dcrlibwallet
 
 class NetworkModeTableViewController: UITableViewController {
     @IBOutlet weak var spv_cell: UITableViewCell!
@@ -35,7 +36,7 @@ class NetworkModeTableViewController: UITableViewController {
         spv_cell.accessoryType = .none
         remote_cell.accessoryType = .none
         tableView.cellForRow(at: indexPath as IndexPath)?.accessoryType = .checkmark
-        Settings.setValue(indexPath.row, for: Settings.Keys.NetworkMode)
+        Settings.setIntValue(indexPath.row, for: DcrlibwalletNetworkModeConfigKey)
     }
     
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {

--- a/Decred Wallet/Features/Settings/PeerSetTableViewController.swift
+++ b/Decred Wallet/Features/Settings/PeerSetTableViewController.swift
@@ -2,11 +2,12 @@
 //  PeerSetTableViewController.swift
 //  Decred Wallet
 //
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 import UIKit
+import Dcrlibwallet
 
 class PeerSetTableViewController: UITableViewController {
     
@@ -18,7 +19,7 @@ class PeerSetTableViewController: UITableViewController {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(save))
         self.navigationItem.title = LocalizedStrings.connectToPeer
         // Do any additional setup after loading the view.
-        peer_ip?.text = Settings.readOptionalValue(for: Settings.Keys.SPVPeerIP) ?? ""
+        peer_ip?.text = Settings.readStringValue(for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -36,13 +37,13 @@ class PeerSetTableViewController: UITableViewController {
         print("saving")
         if (peer_ip.text?.isEmpty)! || (peer_ip.text)! == ""{
             print("saving nothing")
-            Settings.setValue("", for: Settings.Keys.SPVPeerIP)
+            Settings.setStringValue("", for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
             self.navigationController?.popViewController(animated: true)
             return
         }
         else if isValidIP(s: peer_ip.text!){
             print("saving \(String(describing: peer_ip.text))")
-            Settings.setValue(peer_ip.text!, for: Settings.Keys.SPVPeerIP)
+            Settings.setStringValue(peer_ip.text!, for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
             self.navigationController?.popViewController(animated: true)
             return
             }

--- a/Decred Wallet/Features/Settings/ServerSetTableViewController.swift
+++ b/Decred Wallet/Features/Settings/ServerSetTableViewController.swift
@@ -2,11 +2,12 @@
 //  ServerSetTableViewController.swift
 //  Decred Wallet
 //
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 import UIKit
+import Dcrlibwallet
 
 class ServerSetTableViewController: UITableViewController {
     
@@ -18,7 +19,7 @@ class ServerSetTableViewController: UITableViewController {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(save))
         self.navigationItem.title = LocalizedStrings.serverAddress
-        server_ip?.text = Settings.readOptionalValue(for: Settings.Keys.RemoteServerIP) ?? ""
+        server_ip?.text = Settings.readStringValue(for: DcrlibwalletUserAgentConfigKey)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -34,12 +35,12 @@ class ServerSetTableViewController: UITableViewController {
     @objc func save() -> Void {
         // save here
         guard let ipAddress = server_ip.text, ipAddress != "" else {
-            Settings.setValue("", for: Settings.Keys.RemoteServerIP)
+            Settings.setStringValue("", for: DcrlibwalletUserAgentConfigKey)
             self.navigationController?.popViewController(animated: true)
             return
         }
         if isValidIP(s: server_ip.text!) {
-            Settings.setValue(server_ip.text!, for: Settings.Keys.RemoteServerIP)
+            Settings.setStringValue(server_ip.text!, for: DcrlibwalletUserAgentConfigKey)
             self.navigationController?.popViewController(animated: true)
             return
         } else {

--- a/Decred Wallet/Features/Settings/ServerSetTableViewController.swift
+++ b/Decred Wallet/Features/Settings/ServerSetTableViewController.swift
@@ -19,7 +19,7 @@ class ServerSetTableViewController: UITableViewController {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(save))
         self.navigationItem.title = LocalizedStrings.serverAddress
-        server_ip?.text = Settings.readStringValue(for: DcrlibwalletUserAgentConfigKey)
+        server_ip?.text = "" // deprecated in v2
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -33,19 +33,7 @@ class ServerSetTableViewController: UITableViewController {
     }
     
     @objc func save() -> Void {
-        // save here
-        guard let ipAddress = server_ip.text, ipAddress != "" else {
-            Settings.setStringValue("", for: DcrlibwalletUserAgentConfigKey)
-            self.navigationController?.popViewController(animated: true)
-            return
-        }
-        if isValidIP(s: server_ip.text!) {
-            Settings.setStringValue(server_ip.text!, for: DcrlibwalletUserAgentConfigKey)
-            self.navigationController?.popViewController(animated: true)
-            return
-        } else {
-            self.showMessage(title: LocalizedStrings.invalidInput, userMessage: LocalizedStrings.remoteAddressIsInvalid, buttonTitle: LocalizedStrings.ok)
-        }
+        // no longer saving full node server ip, feature deprecated in v2
     }
     
     @objc func cancel() -> Void {

--- a/Decred Wallet/Features/Settings/SettingsController.swift
+++ b/Decred Wallet/Features/Settings/SettingsController.swift
@@ -76,7 +76,7 @@ class SettingsController: UITableViewController  {
         }
         
         connect_peer_ip?.text = Settings.readStringValue(for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
-        server_ip?.text = Settings.readStringValue(for: DcrlibwalletUserAgentConfigKey)
+        server_ip?.text = "" // deprecated in v2
         
         loadSettingsData()
         self.checkStartupSecurity()
@@ -112,7 +112,7 @@ class SettingsController: UITableViewController  {
         build?.text = dateformater.string(from: AppDelegate.compileDate as Date)
         spend_uncon_fund?.setOn(Settings.spendUnconfirmed, animated: false)
         connect_peer_ip?.text = Settings.readStringValue(for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
-        server_ip?.text = Settings.readStringValue(for: DcrlibwalletUserAgentConfigKey)
+        server_ip?.text = "" // deprecated in v2
         incoming_notification_switch?.setOn(Settings.incomingNotificationEnabled, animated: true)
         
         self.cellularSyncSwitch.isOn = Settings.readBoolValue(for: DcrlibwalletSyncOnCellularConfigKey)

--- a/Decred Wallet/Features/Settings/SettingsController.swift
+++ b/Decred Wallet/Features/Settings/SettingsController.swift
@@ -46,20 +46,21 @@ class SettingsController: UITableViewController  {
         var fieldToUpdate: String?
         switch switchView {
         case self.spend_uncon_fund:
-            fieldToUpdate = Settings.Keys.SpendUnconfirmed
+            fieldToUpdate = DcrlibwalletSpendUnconfirmedConfigKey
             
         case self.incoming_notification_switch:
-            fieldToUpdate = Settings.Keys.IncomingNotification
+            // should be set per wallet, rather than once for all wallets
+            break
             
         case self.cellularSyncSwitch:
-            fieldToUpdate = Settings.Keys.SyncOnCellular
+            fieldToUpdate = DcrlibwalletSyncOnCellularConfigKey
             
         default:
             return
         }
         
         if fieldToUpdate != nil {
-            Settings.setValue(switchView.isOn, for: fieldToUpdate!)
+            Settings.setBoolValue(switchView.isOn, for: fieldToUpdate!)
         }
     }
     
@@ -74,8 +75,8 @@ class SettingsController: UITableViewController  {
             self.addNavigationBackButton()
         }
         
-        connect_peer_ip?.text = Settings.readOptionalValue(for: Settings.Keys.SPVPeerIP) ?? ""
-        server_ip?.text = Settings.readOptionalValue(for: Settings.Keys.RemoteServerIP) ?? ""
+        connect_peer_ip?.text = Settings.readStringValue(for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
+        server_ip?.text = Settings.readStringValue(for: DcrlibwalletUserAgentConfigKey)
         
         loadSettingsData()
         self.checkStartupSecurity()
@@ -110,11 +111,11 @@ class SettingsController: UITableViewController  {
         dateformater.dateFormat = "yyyy-MM-dd"
         build?.text = dateformater.string(from: AppDelegate.compileDate as Date)
         spend_uncon_fund?.setOn(Settings.spendUnconfirmed, animated: false)
-        connect_peer_ip?.text = Settings.readOptionalValue(for: Settings.Keys.SPVPeerIP) ?? ""
-        server_ip?.text = Settings.readOptionalValue(for: Settings.Keys.RemoteServerIP) ?? ""
+        connect_peer_ip?.text = Settings.readStringValue(for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
+        server_ip?.text = Settings.readStringValue(for: DcrlibwalletUserAgentConfigKey)
         incoming_notification_switch?.setOn(Settings.incomingNotificationEnabled, animated: true)
         
-        self.cellularSyncSwitch.isOn = Settings.readValue(for: Settings.Keys.SyncOnCellular)
+        self.cellularSyncSwitch.isOn = Settings.readBoolValue(for: DcrlibwalletSyncOnCellularConfigKey)
         
         if Settings.networkMode == 0 {
             network_mode_subtitle?.text = LocalizedStrings.spv

--- a/Decred Wallet/Features/Wallet Utils/Security.swift
+++ b/Decred Wallet/Features/Wallet Utils/Security.swift
@@ -52,8 +52,12 @@ class Security: NSObject {
     private var callbacks = RequestCallbacks()
     private var currentSecurityType: SecurityType?
     
-    static func startup() -> Security {
-        return Security(for: .Startup)
+    static func startup(legacy: Bool = false) -> Security {
+        let startupSecurity = Security(for: .Startup)
+        if legacy {
+            startupSecurity.currentSecurityType = StartupPinOrPassword.legacySecurityType()
+        }
+        return startupSecurity
     }
     
     static func spending() -> Security {

--- a/Decred Wallet/Features/Wallet Utils/Security.swift
+++ b/Decred Wallet/Features/Wallet Utils/Security.swift
@@ -11,6 +11,15 @@ import UIKit
 enum SecurityType: String {
     case password = "PASSWORD"
     case pin = "PIN"
+    
+    var localizedString: String {
+        switch self {
+        case .pin:
+            return LocalizedStrings.pin
+        case .password:
+            return LocalizedStrings.password.lowercased()
+        }
+    }
 }
 
 class Security: NSObject {
@@ -52,12 +61,8 @@ class Security: NSObject {
     private var callbacks = RequestCallbacks()
     private var currentSecurityType: SecurityType?
     
-    static func startup(legacy: Bool = false) -> Security {
-        let startupSecurity = Security(for: .Startup)
-        if legacy {
-            startupSecurity.currentSecurityType = StartupPinOrPassword.legacySecurityType()
-        }
-        return startupSecurity
+    static func startup() -> Security {
+        return Security(for: .Startup)
     }
     
     static func spending() -> Security {

--- a/Decred Wallet/Features/Wallet Utils/SingleToMultiWalletMigration.swift
+++ b/Decred Wallet/Features/Wallet Utils/SingleToMultiWalletMigration.swift
@@ -167,7 +167,7 @@ fileprivate struct PreMultiWalletSettings {
             Settings.setStringValue(lastTxHash, for: DcrlibwalletLastTxHashConfigKey)
         }
         
-//        UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
-//        UserDefaults.standard.synchronize()
+        UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+        UserDefaults.standard.synchronize()
     }
 }

--- a/Decred Wallet/Features/Wallet Utils/SingleToMultiWalletMigration.swift
+++ b/Decred Wallet/Features/Wallet Utils/SingleToMultiWalletMigration.swift
@@ -1,0 +1,164 @@
+//
+//  SingleToMultiWalletMigration.swift
+//  Decred Wallet
+//
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+import UIKit
+import Dcrlibwallet
+
+class SingleToMultiWalletMigration {
+    static var migrationNeeded: Bool {
+        return WalletLoader.shared.multiWallet.v1WalletExists()
+    }
+    
+    // Requires startup passphrase (aka wallet public passphrase) to
+    // disable public passphrase security on the wallet after migrating.
+    // The startup passphrase will continue to be used as the app's startup passphrase.
+    static func migrateExistingWallet() {
+        if PreMultiWalletSettings.readValue(for: .IsStartupSecuritySet) ?? false {
+            SingleToMultiWalletMigration.self.migrate(startupPinOrPassword: "", completion: nil)
+            return
+        }
+        
+        var securityRequestVC: SecurityCodeRequestBaseViewController
+        var startupSecurityType: String
+        
+        if PreMultiWalletSettings.readValue(for: .StartupSecurityType) == SecurityType.password.rawValue {
+            securityRequestVC = RequestPasswordViewController.instantiate(from: .Security)
+            startupSecurityType = SecurityType.password.localizedString
+        } else {
+            securityRequestVC = RequestPinViewController.instantiate(from: .Security)
+            startupSecurityType = SecurityType.pin.localizedString
+        }
+        
+        securityRequestVC.request = Security.Request(for: .Startup)
+        securityRequestVC.request.prompt = String(format: LocalizedStrings.unlockWithStartupCode, startupSecurityType)
+        securityRequestVC.request.submitBtnText = LocalizedStrings.unlock
+        securityRequestVC.request.showCancelButton = false
+        
+        securityRequestVC.callbacks.onSecurityCodeEntered = SingleToMultiWalletMigration.self.migrate
+        
+        securityRequestVC.modalPresentationStyle = .pageSheet
+        AppDelegate.shared.window?.rootViewController?.present(securityRequestVC, animated: true)
+    }
+    
+    private static func migrate(startupPinOrPassword: String,
+                                securityType: SecurityType? = nil,
+                                completion: SecurityCodeRequestCompletionDelegate?) {
+        
+        var privatePassphraseType = DcrlibwalletPassphraseTypePass
+        if PreMultiWalletSettings.readValue(for: .StartupSecurityType) == SecurityType.password.rawValue {
+            privatePassphraseType = DcrlibwalletPassphraseTypePin
+        }
+        
+        var startupSecurityType = DcrlibwalletPassphraseTypePass
+        if securityType == .pin {
+            startupSecurityType = DcrlibwalletPassphraseTypePin
+        }
+        
+        do {
+            try WalletLoader.shared.multiWallet.migrateV1Wallet(startupPinOrPassword,
+                                                                originalPrivatePassType: privatePassphraseType)
+            
+            // attempt to re-set the app startup passphrase
+            try? WalletLoader.shared.multiWallet.setStartupPassphrase(startupPinOrPassword.utf8Bits,
+                                                                      passphraseType: startupSecurityType)
+            
+            PreMultiWalletSettings.migrateUserConfig()
+            
+            DispatchQueue.main.async {
+                completion?.securityCodeProcessed()
+                NavigationMenuTabBarController.setupMenuAndLaunchApp(isNewWallet: false)
+            }
+            
+        } catch let error {
+            print("link existing wallet error: \(error.localizedDescription)")
+            
+            DispatchQueue.main.async {
+                if error.isInvalidPassphraseError {
+                    completion?.securityCodeError(errorMessage: StartupPinOrPassword.invalidSecurityCodeMessage())
+                } else {
+                    completion?.securityCodeError(errorMessage: error.localizedDescription)
+                }
+            }
+        }
+    }
+}
+
+// PreMultiWalletSettings retained for use in migrating user preferences
+// to the new multiwallet config feature.
+fileprivate struct PreMultiWalletSettings {
+    enum Key: String {
+        // These are now saved directly by multiwallet when setting a startup passphrase.
+        case IsStartupSecuritySet = "startup_security_set"
+        case StartupSecurityType = "startup_security_type"
+        
+        // This is saved by multiwallet in the call to `multiWallet.migrateV1Wallet()`.
+        case SpendingPassphraseSecurityType = "spending_security_type"
+        
+        case SPVPeerIP = "pref_peer_ip"
+        case RemoteServerIP = "pref_server_ip"
+        case SyncOnCellular = "always_sync"
+        
+        case SpendUnconfirmed = "pref_spend_unconfirmed"
+        case IncomingNotification = "pref_notification_switch"
+        case CurrencyConversionOption = "currency_conversion_option"
+        case NetworkMode = "network_mode"
+        
+        case LastTxHash = "last_tx_hash"
+    }
+    
+    static func readValue<T>(for key: Key) -> T? {
+        if T.self == Bool.self {
+            return UserDefaults.standard.bool(forKey: key.rawValue) as? T
+        }
+        return UserDefaults.standard.value(forKey: key.rawValue) as? T
+    }
+    
+    static func migrateUserConfig() {
+        if let spvPeerIP: String = readValue(for: .SPVPeerIP) {
+            Settings.setStringValue(spvPeerIP, for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
+        }
+        
+        if let remoteServerIP: String = readValue(for: .RemoteServerIP) {
+            Settings.setStringValue(remoteServerIP, for: DcrlibwalletUserAgentConfigKey)
+        }
+        
+        if let syncOnCellular: Bool = readValue(for: .SyncOnCellular) {
+            Settings.setBoolValue(syncOnCellular, for: DcrlibwalletSyncOnCellularConfigKey)
+        }
+        
+        if let spendUnconfirmed: Bool = readValue(for: .SpendUnconfirmed) {
+            Settings.setBoolValue(spendUnconfirmed, for: DcrlibwalletSpendUnconfirmedConfigKey)
+        }
+        
+        if let incomingNotificationEnabled: Bool = readValue(for: .IncomingNotification) {
+            // todo update this default notification status when implementing wallets page -> wallet settings.
+            let notificationStatus = incomingNotificationEnabled ? "vibration" : "off"
+            if  incomingNotificationEnabled {
+                WalletLoader.shared.wallets.forEach({
+                    try? WalletLoader.shared.multiWallet
+                        .updateIncomingNotificationsUserPreference($0.id_, notificationsPref: notificationStatus)
+                })
+            }
+        }
+        
+        if let currencyConversionOption: String = readValue(for: .CurrencyConversionOption) {
+            Settings.setStringValue(currencyConversionOption, for: DcrlibwalletCurrencyConversionConfigKey)
+        }
+        
+        if let networkMode: Int = readValue(for: .NetworkMode) {
+            Settings.setIntValue(networkMode, for: DcrlibwalletNetworkModeConfigKey)
+        }
+        
+        if let lastTxHash: String = readValue(for: .LastTxHash) {
+            Settings.setStringValue(lastTxHash, for: DcrlibwalletLastTxHashConfigKey)
+        }
+        
+        UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+        UserDefaults.standard.synchronize()
+    }
+}

--- a/Decred Wallet/Features/Wallet Utils/SingleToMultiWalletMigration.swift
+++ b/Decred Wallet/Features/Wallet Utils/SingleToMultiWalletMigration.swift
@@ -104,7 +104,6 @@ fileprivate struct PreMultiWalletSettings {
         case SpendingPassphraseSecurityType = "spending_security_type"
         
         case SPVPeerIP = "pref_peer_ip"
-        case RemoteServerIP = "pref_server_ip"
         case SyncOnCellular = "always_sync"
         
         case SpendUnconfirmed = "pref_spend_unconfirmed"
@@ -132,10 +131,6 @@ fileprivate struct PreMultiWalletSettings {
     static func migrateUserConfig() {
         if let spvPeerIP: String = readOptionalValue(for: .SPVPeerIP) {
             Settings.setStringValue(spvPeerIP, for: DcrlibwalletSpvPersistentPeerAddressesConfigKey)
-        }
-        
-        if let remoteServerIP: String = readOptionalValue(for: .RemoteServerIP) {
-            Settings.setStringValue(remoteServerIP, for: DcrlibwalletUserAgentConfigKey)
         }
         
         if let syncOnCellular: Bool = readValue(for: .SyncOnCellular) {

--- a/Decred Wallet/Features/Wallet Utils/SpendingPinOrPassword.swift
+++ b/Decred Wallet/Features/Wallet Utils/SpendingPinOrPassword.swift
@@ -41,7 +41,6 @@ struct SpendingPinOrPassword {
                 DispatchQueue.main.async {
                     newCodeRequestCompletion?.securityCodeProcessed()
                     currentCodeRequestCompletion?.securityCodeProcessed()
-                    Settings.setValue(newCodeType.rawValue, for: Settings.Keys.SpendingPassphraseSecurityType)
                 }
             } catch let error {
                 DispatchQueue.main.async {
@@ -57,7 +56,7 @@ struct SpendingPinOrPassword {
     }
     
     static func currentSecurityType() -> SecurityType {
-        if Settings.readOptionalValue(for: Settings.Keys.SpendingPassphraseSecurityType) == SecurityType.pin.rawValue {
+        if WalletLoader.shared.firstWallet!.privatePassphraseType == DcrlibwalletPassphraseTypePin {
             return .pin
         }
         return .password

--- a/Decred Wallet/Features/Wallet Utils/StartupPinOrPassword.swift
+++ b/Decred Wallet/Features/Wallet Utils/StartupPinOrPassword.swift
@@ -88,14 +88,6 @@ struct StartupPinOrPassword {
                                                                             passphraseType: passphraseType)
 
                 DispatchQueue.main.async {
-                    if newCode == "" {
-                        Settings.setValue(false, for: Settings.Keys.IsStartupSecuritySet)
-                        Settings.clearValue(for: Settings.Keys.StartupSecurityType)
-                    } else {
-                        Settings.setValue(true, for: Settings.Keys.IsStartupSecuritySet)
-                        Settings.setValue(newCodeType!.rawValue, for: Settings.Keys.StartupSecurityType)
-                    }
-                    
                     newCodeRequestCompletion?.securityCodeProcessed()
                     currentCodeRequestCompletion?.securityCodeProcessed()
                     done?()
@@ -112,13 +104,24 @@ struct StartupPinOrPassword {
             }
         }
     }
+    
+    static func legacyPinOrPasswordIsSet() -> Bool {
+        return Settings.Legacy.readValue(for: Settings.Legacy.Keys.IsStartupSecuritySet) ?? false
+    }
 
+    static func legacySecurityType() -> SecurityType {
+        if Settings.Legacy.readValue(for: Settings.Legacy.Keys.StartupSecurityType) == SecurityType.pin.rawValue {
+            return .pin
+        }
+        return .password
+    }
+    
     static func pinOrPasswordIsSet() -> Bool {
-        return Settings.readValue(for: Settings.Keys.IsStartupSecuritySet)
+        return WalletLoader.shared.multiWallet.isStartupSecuritySet()
     }
 
     static func currentSecurityType() -> SecurityType {
-        if Settings.readOptionalValue(for: Settings.Keys.StartupSecurityType) == SecurityType.pin.rawValue {
+        if WalletLoader.shared.multiWallet.startupSecurityType() == DcrlibwalletPassphraseTypePin {
             return .pin
         }
         return .password

--- a/Decred Wallet/Features/Wallet Utils/StartupPinOrPassword.swift
+++ b/Decred Wallet/Features/Wallet Utils/StartupPinOrPassword.swift
@@ -105,17 +105,6 @@ struct StartupPinOrPassword {
         }
     }
     
-    static func legacyPinOrPasswordIsSet() -> Bool {
-        return Settings.Legacy.readValue(for: Settings.Legacy.Keys.IsStartupSecuritySet) ?? false
-    }
-
-    static func legacySecurityType() -> SecurityType {
-        if Settings.Legacy.readValue(for: Settings.Legacy.Keys.StartupSecurityType) == SecurityType.pin.rawValue {
-            return .pin
-        }
-        return .password
-    }
-    
     static func pinOrPasswordIsSet() -> Bool {
         return WalletLoader.shared.multiWallet.isStartupSecuritySet()
     }

--- a/Decred Wallet/Features/Wallet Utils/SyncManager.swift
+++ b/Decred Wallet/Features/Wallet Utils/SyncManager.swift
@@ -89,7 +89,7 @@ class SyncManager: NSObject {
         
         // Dialog option to ALWAYS allow syncing on cellular.
         syncConfirmationDialog.addAction(UIAlertAction(title: LocalizedStrings.alwaysAllow, style: .default, handler: { _ in
-            Settings.setValue(true, for: Settings.Keys.SyncOnCellular)
+            Settings.setBoolValue(true, for: DcrlibwalletSyncOnCellularConfigKey)
             self.startOrRestartSync(allowSyncOnCellular: true)
         }))
         

--- a/Decred Wallet/Features/Wallet Utils/WalletLoader.swift
+++ b/Decred Wallet/Features/Wallet Utils/WalletLoader.swift
@@ -71,7 +71,6 @@ class WalletLoader: NSObject {
                 try self.multiWallet.createNewWallet(spendingPinOrPassword, privatePassphraseType: privatePassphraseType)
                 
                 DispatchQueue.main.async {
-                    Settings.setValue(securityType.rawValue, for: Settings.Keys.SpendingPassphraseSecurityType)
                     completion(nil)
                 }
             } catch let error {
@@ -92,7 +91,6 @@ class WalletLoader: NSObject {
                                              privatePassphraseType: privatePassphraseType)
                 
                 DispatchQueue.main.async {
-                    Settings.setValue(securityType.rawValue, for: Settings.Keys.SpendingPassphraseSecurityType)
                     completion(nil)
                 }
             } catch let error {

--- a/Decred Wallet/Features/Wallet Utils/WalletLoader.swift
+++ b/Decred Wallet/Features/Wallet Utils/WalletLoader.swift
@@ -48,21 +48,6 @@ class WalletLoader: NSObject {
         return error
     }
     
-    func linkExistingWalletAndStartApp(startupPinOrPassword: String) throws {
-        var privatePassphraseType = DcrlibwalletPassphraseTypePass
-        if SpendingPinOrPassword.currentSecurityType() == .pin {
-            privatePassphraseType = DcrlibwalletPassphraseTypePin
-        }
-        
-        try self.multiWallet.linkExistingWallet(WalletLoader.appDataDir,
-                                                originalPubPass: startupPinOrPassword,
-                                                privatePassphraseType: privatePassphraseType)
-        
-        DispatchQueue.main.async {
-            NavigationMenuTabBarController.setupMenuAndLaunchApp(isNewWallet: false)
-        }
-    }
-    
     func createWallet(spendingPinOrPassword: String, securityType: SecurityType, completion: @escaping (Error?) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             let privatePassphraseType = securityType == .password ? DcrlibwalletPassphraseTypePass : DcrlibwalletPassphraseTypePin

--- a/Decred Wallet/Utils/Settings.swift
+++ b/Decred Wallet/Utils/Settings.swift
@@ -7,72 +7,114 @@
 // license that can be found in the LICENSE file.
 
 import Foundation
+import Dcrlibwallet
 
 class Settings {
-    struct Keys {
-        static let IsStartupSecuritySet = "startup_security_set"
-        static let StartupSecurityType = "startup_security_type"
-        static let SpendingPassphraseSecurityType = "spending_security_type"
-        static let DefaultWallet = "default_wallet"
-        static let HiddenWalletPrefix = "hidden"
+    // Legacy keys and read function retained for use in migrating legacy user preferences.
+    struct Legacy {
+        struct Keys {
+            static let IsStartupSecuritySet = "startup_security_set"
+            static let StartupSecurityType = "startup_security_type"
+            static let SpendingPassphraseSecurityType = "spending_security_type"
+            static let DefaultWallet = "default_wallet"
+            static let HiddenWalletPrefix = "hidden"
 
-        static let SPVPeerIP = "pref_peer_ip"
-        static let RemoteServerIP = "pref_server_ip"
-        static let SyncOnCellular = "always_sync"
-        
-        static let SpendUnconfirmed = "pref_spend_unconfirmed"
-        static let IncomingNotification = "pref_notification_switch"
-        static let CurrencyConversionOption = "currency_conversion_option"
-        static let NetworkMode = "network_mode"
-        
-        static let LastTxHash = "last_tx_hash"
-    }
-    
-    static func readValue<T>(for key: String) -> T {
-        if T.self == Bool.self {
-            return UserDefaults.standard.bool(forKey: key) as! T
+            static let SPVPeerIP = "pref_peer_ip"
+            static let RemoteServerIP = "pref_server_ip"
+            static let SyncOnCellular = "always_sync"
+            
+            static let SpendUnconfirmed = "pref_spend_unconfirmed"
+            static let IncomingNotification = "pref_notification_switch"
+            static let CurrencyConversionOption = "currency_conversion_option"
+            static let NetworkMode = "network_mode"
+            
+            static let LastTxHash = "last_tx_hash"
         }
-        return UserDefaults.standard.value(forKey: key) as! T
+        
+        static func readValue<T>(for key: String) -> T? {
+            if T.self == Bool.self {
+                return UserDefaults.standard.bool(forKey: key) as? T
+            }
+            return UserDefaults.standard.value(forKey: key) as? T
+        }
     }
     
-    static func readOptionalValue<T>(for key: String) -> T? {
-        return UserDefaults.standard.value(forKey: key) as? T
+    static func setBoolValue(_ value: Bool, for key: String) {
+        WalletLoader.shared.multiWallet.setBoolConfigValueForKey(key, value: value)
     }
     
-    static func setValue(_ value: Any, for key: String) {
-        UserDefaults.standard.set(value, forKey: key)
-        UserDefaults.standard.synchronize()
+    static func setIntValue(_ value: Int, for key: String) {
+        WalletLoader.shared.multiWallet.setIntConfigValueForKey(key, value: value)
+    }
+    
+    static func setInt32Value(_ value: Int32, for key: String) {
+        WalletLoader.shared.multiWallet.setInt32ConfigValueForKey(key, value: value)
+    }
+    
+    static func setInt64Value(_ value: Int64, for key: String) {
+        WalletLoader.shared.multiWallet.setLongConfigValueForKey(key, value: value)
+    }
+    
+    static func setDoubleValue(_ value: Double, for key: String) {
+        WalletLoader.shared.multiWallet.setDoubleConfigValueForKey(key, value: value)
+    }
+    
+    static func setStringValue(_ value: String, for key: String) {
+        WalletLoader.shared.multiWallet.setStringConfigValueForKey(key, value: value)
+    }
+    
+    static func readBoolValue(for key: String, defaultValue: Bool = false) -> Bool {
+        return WalletLoader.shared.multiWallet.readBoolConfigValue(forKey: key, defaultValue: defaultValue)
+    }
+    
+    static func readIntValue(for key: String, defaultValue: Int = 0) -> Int {
+        return WalletLoader.shared.multiWallet.readIntConfigValue(forKey: key, defaultValue: defaultValue)
+    }
+    
+    static func readInt32Value(for key: String, defaultValue: Int32 = 0) -> Int32 {
+        return WalletLoader.shared.multiWallet.readInt32ConfigValue(forKey: key, defaultValue: defaultValue)
+    }
+    
+    static func readInt64Value(for key: String, defaultValue: Int64 = 0) -> Int64 {
+        return WalletLoader.shared.multiWallet.readLongConfigValue(forKey: key, defaultValue: defaultValue)
+    }
+    
+    static func readDoubleValue(for key: String, defaultValue: Double = 0) -> Double {
+        return WalletLoader.shared.multiWallet.readDoubleConfigValue(forKey: key, defaultValue: defaultValue)
+    }
+    
+    static func readStringValue(for key: String, defaultValue: String = "") -> String {
+        return WalletLoader.shared.multiWallet.readStringConfigValue(forKey: key, defaultValue: defaultValue)
     }
     
     static func clear() {
-        UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
-        UserDefaults.standard.synchronize()
+        WalletLoader.shared.multiWallet.clearConfig()
     }
-    
+
     static func clearValue(for key: String) {
-        UserDefaults.standard.removeObject(forKey: key)
-        UserDefaults.standard.synchronize()
+        WalletLoader.shared.multiWallet.deleteUserConfigValue(forKey: key)
     }
     
     /** Computed properties to access commonly used settings. */
     static var syncOnCellular: Bool {
-        return Settings.readValue(for: Settings.Keys.SyncOnCellular)
+        return Settings.readBoolValue(for: DcrlibwalletSyncOnCellularConfigKey)
     }
     
     static var spendUnconfirmed: Bool {
-        return Settings.readValue(for: Settings.Keys.SpendUnconfirmed)
+        return Settings.readBoolValue(for: DcrlibwalletSpendUnconfirmedConfigKey)
     }
     
     static var incomingNotificationEnabled: Bool {
-        return Settings.readValue(for: Settings.Keys.IncomingNotification)
+        // todo, should be checked per wallet henceforth
+        return true
     }
     
     static var currencyConversionOption: CurrencyConversionOption {
-        let selectedOption: String = Settings.readOptionalValue(for: Settings.Keys.CurrencyConversionOption) ?? ""
+        let selectedOption: String = Settings.readStringValue(for: DcrlibwalletCurrencyConversionConfigKey)
         return CurrencyConversionOption(rawValue: selectedOption) ?? .None
     }
     
     static var networkMode: Int {
-        return Settings.readOptionalValue(for: Settings.Keys.NetworkMode) ?? 0
+        return Settings.readIntValue(for: DcrlibwalletNetworkModeConfigKey)
     }
 }

--- a/Decred Wallet/Utils/Settings.swift
+++ b/Decred Wallet/Utils/Settings.swift
@@ -10,35 +10,6 @@ import Foundation
 import Dcrlibwallet
 
 class Settings {
-    // Legacy keys and read function retained for use in migrating legacy user preferences.
-    struct Legacy {
-        struct Keys {
-            static let IsStartupSecuritySet = "startup_security_set"
-            static let StartupSecurityType = "startup_security_type"
-            static let SpendingPassphraseSecurityType = "spending_security_type"
-            static let DefaultWallet = "default_wallet"
-            static let HiddenWalletPrefix = "hidden"
-
-            static let SPVPeerIP = "pref_peer_ip"
-            static let RemoteServerIP = "pref_server_ip"
-            static let SyncOnCellular = "always_sync"
-            
-            static let SpendUnconfirmed = "pref_spend_unconfirmed"
-            static let IncomingNotification = "pref_notification_switch"
-            static let CurrencyConversionOption = "currency_conversion_option"
-            static let NetworkMode = "network_mode"
-            
-            static let LastTxHash = "last_tx_hash"
-        }
-        
-        static func readValue<T>(for key: String) -> T? {
-            if T.self == Bool.self {
-                return UserDefaults.standard.bool(forKey: key) as? T
-            }
-            return UserDefaults.standard.value(forKey: key) as? T
-        }
-    }
-    
     static func setBoolValue(_ value: Bool, for key: String) {
         WalletLoader.shared.multiWallet.setBoolConfigValueForKey(key, value: value)
     }

--- a/Decred Wallet/table_view_cell/AccountDataCell.swift
+++ b/Decred Wallet/table_view_cell/AccountDataCell.swift
@@ -1,7 +1,7 @@
 //  AccountDataCell.swift
 //  Decred Wallet
 //
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -35,14 +35,14 @@ class AccountDataCell: UITableViewCell, AccountDetailsCellProtocol {
         super.setSelected(selected, animated: animated)
     }
     @IBAction func setHiddenAccount(_ sender: Any) {
-        Settings.setValue(hideAcount.isOn, for: "\(Settings.Keys.HiddenWalletPrefix)\(accountTmp.number)")
+        // deprecated
     }
     
     @IBAction func setDefault(_ sender: Any) {
         self.accountTmp.makeDefault()
         self.hideAcount.setOn(false, animated: true)
         self.hideAcount.isEnabled = false
-        Settings.setValue(false, for: "\(Settings.Keys.HiddenWalletPrefix)\(accountTmp.number)")
+        // deprecated
     }
     
     func setup(account: DcrlibwalletAccount) {


### PR DESCRIPTION
Resolves #571 . Requires https://github.com/raedahgroup/dcrlibwallet/pull/98.

Refactored the code for migrating single wallets from the v1 app to the new multiwallet structure. While this PR ensures that subsequent reading/setting user preferences will use the dcrlibwallet config features, it only migrates previously set user preferences if the previous v1 wallet is also migrated. The assumption is that if there is no previous wallet to migrate, then it's likely a fresh app and thus, no previously set preferences to migrate.

Also fixed a bug where attempting to migrate an existing wallet to the new multiwallet structure crashes if the previous existing wallet has a startup passphrase set.