### PR TITLE
refactor v1 wallet migration dcrlibwallet method calls

### DIFF
--- a/Decred Wallet/Wallet Utils/SingleToMultiWalletMigration.swift
+++ b/Decred Wallet/Wallet Utils/SingleToMultiWalletMigration.swift
@@ -10,8 +10,12 @@ import UIKit
 import Dcrlibwallet
 
 class SingleToMultiWalletMigration {
+    static var v1WalletDbDir: String {
+        return "\(WalletLoader.appDataDir)/\(BuildConfig.NetType)"
+    }
+
     static var migrationNeeded: Bool {
-        return WalletLoader.shared.multiWallet.v1WalletExists()
+        return DcrlibwalletWalletExistsAt(v1WalletDbDir)
     }
     
     // Requires startup passphrase (aka wallet public passphrase) to
@@ -61,8 +65,9 @@ class SingleToMultiWalletMigration {
         
         DispatchQueue.global(qos: .userInitiated).async {
             do {
-                try WalletLoader.shared.multiWallet.migrateV1Wallet(startupPinOrPassword,
-                                                                    originalPrivatePassType: privatePassphraseType)
+                try WalletLoader.shared.multiWallet.linkExistingWallet(v1WalletDbDir,
+                                                                       originalPubPass: startupPinOrPassword,
+                                                                       privatePassphraseType: privatePassphraseType)
                 
                 // attempt to re-set the app startup passphrase
                 if startupPinOrPassword != "" {


### PR DESCRIPTION
dcrlibwallet removed alias methods for migrating/linking existing wallets in https://github.com/raedahgroup/dcrlibwallet/pull/98/commits/735e861a1ee68c314678a60d297b1ac7018e2157.

dcrios currently uses those alias methods and now uses the base methods directly.