### PR TITLE
multi: cleanups, improvements and fixes

### DIFF
--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -127,17 +127,17 @@ extension DcrlibwalletWallet {
     }
 
     func transactionHistory(offset: Int32, count: Int32 = 0, filter: Int32 = DcrlibwalletTxFilterAll, newestFirst:Bool = true) -> [Transaction]? {
-        guard let wallet = WalletLoader.shared.firstWallet else {
-            return nil
-        }
-        
         var error: NSError?
-        let allTransactionsJson = wallet.getTransactions(offset, limit: count, txFilter: filter, newestFirst: newestFirst, error: &error)
+        let allTransactionsJson = self.getTransactions(offset, limit: count, txFilter: filter, newestFirst: newestFirst, error: &error)
         if error != nil {
             print("wallet.getTransactions error:", error!.localizedDescription)
             return nil
         }
         
+        if allTransactionsJson.isEmpty {
+            return []
+        }
+
         var transactions: [Transaction]?
         do {
             transactions = try JSONDecoder().decode([Transaction].self, from: allTransactionsJson.data(using: .utf8)!)
@@ -172,5 +172,42 @@ extension DcrlibwalletMultiWallet {
             totalBalance += wallet.totalWalletBalance(confirmations: confirmations)
         }
         return totalBalance
+    }
+
+    func transactionHistory(offset: Int32, count: Int32 = 0, filter: Int32 = DcrlibwalletTxFilterAll, newestFirst:Bool = true) -> [Transaction]? {
+        var error: NSError?
+        let allTransactionsJson = self.getTransactions(offset, limit: count, txFilter: filter, newestFirst: newestFirst, error: &error)
+        if error != nil {
+            print("multiwallet.getTransactions error:", error!.localizedDescription)
+            return nil
+        }
+
+        if allTransactionsJson.isEmpty {
+            return []
+        }
+
+        var transactions: [Transaction]?
+        do {
+            transactions = try JSONDecoder().decode([Transaction].self, from: allTransactionsJson.data(using: .utf8)!)
+        } catch let error {
+            print("decode multiwallet transactions json error:", error.localizedDescription)
+        }
+
+        if transactions != nil {
+            // Check if there are new transactions since last time wallet history was displayed.
+            let lastTxHash = Settings.readStringValue(for: DcrlibwalletLastTxHashConfigKey)
+            for i in 0..<transactions!.count {
+                if transactions![i].hash == lastTxHash {
+                    // We've hit the last viewed tx. No need to animate this tx or futher txs.
+                    break
+                }
+                transactions![i].animate = true
+            }
+            
+            // Save hash for tx index 0 as last viewed tx hash.
+            Settings.setStringValue(transactions![0].hash, for: DcrlibwalletLastTxHashConfigKey)
+        }
+
+        return transactions
     }
 }

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -128,8 +128,6 @@ class OverviewViewController: UIViewController {
         self.totalSyncProgressView.layer.cornerRadius = 8
         self.showSyncDetailsButton.addBorder(atPosition: .top, color: UIColor.appColors.gray, thickness: 0.62)
         self.syncDetailsSection.horizontalBorder(borderColor: UIColor.appColors.gray, yPosition: 0, borderHeight: 0.62)
-    
-        MultiWalletSyncDetailsLoader.setup(for: self.multipleWalletsSyncDetailsTableView)
     }
     
     @objc func refreshRecentActivityAndUpdateBalance() {
@@ -147,12 +145,13 @@ class OverviewViewController: UIViewController {
     
     func updateRecentActivity() {
         // Fetch 3 most recent transactions
-        // todo this should be a multiwallet fetch rather than a wallet fetch!
-        guard let transactions = WalletLoader.shared.firstWallet?.transactionHistory(offset: 0, count: 3) else {
-            self.recentTransactionsTableView.isHidden = true
-            self.showAllTransactionsButton.isHidden = true
-            self.noTransactionsLabelView.superview?.isHidden = false
-            return
+        guard let transactions = WalletLoader.shared.multiWallet.transactionHistory(offset: 0, count: 3),
+            !transactions.isEmpty
+            else {
+                self.recentTransactionsTableView.isHidden = true
+                self.showAllTransactionsButton.isHidden = true
+                self.noTransactionsLabelView.superview?.isHidden = false
+                return
         }
         
         if transactions.count == 0 {
@@ -241,7 +240,9 @@ class OverviewViewController: UIViewController {
         self.syncCurrentStepReportLabel.text = ""
         self.syncCurrentStepProgressLabel.text = ""
         self.peerCountLabel.text = "\(WalletLoader.shared.multiWallet.connectedPeers())"
+
         self.multipleWalletsPeerCountLabel.text = "\(WalletLoader.shared.multiWallet.connectedPeers())"
+        MultiWalletSyncDetailsLoader.setup(for: self.multipleWalletsSyncDetailsTableView)
     }
     
     private func displayLatestBlockHeightAndAge() {
@@ -467,7 +468,7 @@ extension OverviewViewController: DcrlibwalletSyncProgressListenerProtocol {
             self.syncStatusLabel.text = LocalizedStrings.synchronizing
             self.displayGeneralSyncProgress(report.generalSyncProgress)
             
-            self.syncCurrentStepNumberLabel.text = String(format: LocalizedStrings.syncSteps, 1)
+            self.syncCurrentStepNumberLabel.text = String(format: LocalizedStrings.syncSteps, 3)
             self.syncCurrentStepSummaryLabel.text = String(format: LocalizedStrings.headersScannedProgress, report.rescanProgress)
             
             self.syncCurrentStepTitleLabel.text = LocalizedStrings.blockHeaderScanned


### PR DESCRIPTION
- fix multiwallet active sync details display crash on add new wallet (resolves #597)
- overview page - use multiwallet tx history on recent activity table
- overview page - display "3/3" instead of "1/3" for stage 3 sync progress
- fix bug where wallet.transactionHistory loads first wallet's transactions for all wallets
- don't log tx history fetch error for wallets with no txs