### PR TITLE
tx history loading: properly handle no wallet txs cases

### DIFF
--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -78,6 +78,14 @@ extension DcrlibwalletLibWallet {
                 if getTransactionsError != nil {
                     throw getTransactionsError!
                 }
+                
+                if transactionsJson == nil || transactionsJson!.isEmpty {
+                    DispatchQueue.main.async {
+                        completion([])
+                    }
+                    return
+                }
+                
                 var transactions = try JSONDecoder().decode([Transaction].self, from: transactionsJson!.utf8Bits)
                 
                 // Check if there are new transactions since last time wallet history was displayed.


### PR DESCRIPTION
Fixes an issue where the following error log gets printed when trying to load history for a wallet with no txs.
```
tx history error: The data couldn’t be read because it isn’t in the correct format.
```