### PR TITLE
Fixed transaction list update

### DIFF
--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -539,7 +539,12 @@ extension OverviewViewController: DcrlibwalletSyncProgressListenerProtocol {
 
 extension OverviewViewController: DcrlibwalletTxAndBlockNotificationListenerProtocol {
     func onBlockAttached(_ walletID: Int, blockHeight: Int32) {
-        // not relevant to this VC
+        let unconfirmedTransactions = self.recentTransactions.filter {$0.confirmations <= 2}.count
+        if unconfirmedTransactions > 0 {
+            DispatchQueue.main.async {
+                self.updateRecentActivity()
+            }
+        }
     }
     
     func onTransaction(_ transaction: String?) {
@@ -566,7 +571,7 @@ extension OverviewViewController: DcrlibwalletTxAndBlockNotificationListenerProt
     func onTransactionConfirmed(_ walletID: Int, hash: String?, blockHeight: Int32) {
         DispatchQueue.main.async {
             self.updateMultiWalletBalance()
-            self.recentTransactionsTableView.reloadData()
+            self.updateRecentActivity()
         }
     }
 }

--- a/Decred Wallet/Features/Transactions/TransactionsViewController.swift
+++ b/Decred Wallet/Features/Transactions/TransactionsViewController.swift
@@ -251,7 +251,12 @@ extension TransactionsViewController: UITableViewDataSource, UITableViewDelegate
 
 extension TransactionsViewController: DcrlibwalletTxAndBlockNotificationListenerProtocol {
     func onBlockAttached(_ walletID: Int, blockHeight: Int32) {
-        // not relevant to this VC
+        let unconfirmedTransactions = self.allTransactions.filter {$0.confirmations <= 2}.count
+        if unconfirmedTransactions > 0 {
+            DispatchQueue.main.async {
+                self.reloadTxsForCurrentFilter()
+            }
+        }
     }
 
     func onTransaction(_ transaction: String?) {
@@ -280,7 +285,7 @@ extension TransactionsViewController: DcrlibwalletTxAndBlockNotificationListener
     func onTransactionConfirmed(_ walletID: Int, hash: String?, blockHeight: Int32) {
         // all tx statuses will be updated when table rows are reloaded.
          DispatchQueue.main.async {
-            self.txTableView.reloadData()
+            self.reloadTxsForCurrentFilter()
         }
     }
 }


### PR DESCRIPTION
Fix transaction list update for unconfirmed transactions when new block is attached 
closes #642
Sent 
<img width="300" alt="Screenshot 2020-04-26 at 23 36 33" src="https://user-images.githubusercontent.com/794430/80321926-23899300-8819-11ea-87b3-7427422da2ab.png">

Receive
<img width="300" alt="Screenshot 2020-04-26 at 23 36 24" src="https://user-images.githubusercontent.com/794430/80321932-2edcbe80-8819-11ea-99a6-7dc3c0d06788.png">

<img width="300" alt="Screenshot 2020-04-26 at 23 37 16" src="https://user-images.githubusercontent.com/794430/80321939-38febd00-8819-11ea-982a-c68a2079f239.png">

<img width="300" alt="Screenshot 2020-04-26 at 23 37 07" src="https://user-images.githubusercontent.com/794430/80322001-b6c2c880-8819-11ea-9b26-beb31f6405e6.png">

<img width="300" alt="Screenshot 2020-04-26 at 23 40 16" src="https://user-images.githubusercontent.com/794430/80321944-47e56f80-8819-11ea-8402-de8debaab657.png">

<img width="300" alt="Screenshot 2020-04-26 at 23 40 26" src="https://user-images.githubusercontent.com/794430/80321943-47e56f80-8819-11ea-8c6c-c6ec1ad6bc47.png">

<img width="300" alt="Screenshot 2020-04-26 at 23 40 42" src="https://user-images.githubusercontent.com/794430/80321946-4ae06000-8819-11ea-8aec-b17f75de0cfd.png">

<img width="300" alt="Screenshot 2020-04-26 at 23 40 51" src="https://user-images.githubusercontent.com/794430/80321948-4f0c7d80-8819-11ea-993c-cb9c8129eb9d.png">
