### PR TITLE
Fix transaction notification per wallet

### DIFF
--- a/Decred Wallet/Features/Wallets/WalletSettings.swift
+++ b/Decred Wallet/Features/Wallets/WalletSettings.swift
@@ -38,7 +38,7 @@ class WalletSettings {
     }
     
     var txNotificationAlert: NotificationAlert {
-        let selectedOption: String = self.readStringValue(for: DcrlibwalletIncomingTxNotificationsConfigKey)
+        let selectedOption: String = self.readStringValue(for: "\(self.wallet.id_)\(DcrlibwalletIncomingTxNotificationsConfigKey)")
         return NotificationAlert(rawValue: selectedOption) ?? .none
     }
 }

--- a/Decred Wallet/Features/Wallets/WalletSettingsViewController.swift
+++ b/Decred Wallet/Features/Wallets/WalletSettingsViewController.swift
@@ -56,7 +56,7 @@ class WalletSettingsViewController: UIViewController {
                 return
         }
         
-        self.walletSettings.setStringValue(newSetting.rawValue, for: DcrlibwalletIncomingTxNotificationsConfigKey)
+        self.walletSettings.setStringValue(newSetting.rawValue, for: "\(self.wallet.id_)\(DcrlibwalletIncomingTxNotificationsConfigKey)")
         self.incomingTxAlertButton.setTitle(newSetting.localizedString, for: .normal)
     }
     

--- a/Decred Wallet/Utils/Settings.swift
+++ b/Decred Wallet/Utils/Settings.swift
@@ -75,11 +75,6 @@ class Settings {
         return Settings.readBoolValue(for: DcrlibwalletSpendUnconfirmedConfigKey)
     }
     
-    static var incomingNotificationEnabled: Bool {
-        // todo, should be checked per wallet henceforth
-        return true
-    }
-    
     static var beepNewBlocks: Bool {
         return Settings.readBoolValue(for: DcrlibwalletBeepNewBlocksConfigKey)
     }

--- a/Decred Wallet/Wallet Utils/TransactionNotification.swift
+++ b/Decred Wallet/Wallet Utils/TransactionNotification.swift
@@ -70,7 +70,7 @@ class TransactionNotification: NSObject {
             return
         }
         
-        if tx!.fee == 0 && WalletSettings(for: affectedWallet).txNotificationAlert != .none {
+        if tx!.direction == DcrlibwalletTxDirectionReceived && WalletSettings(for: affectedWallet).txNotificationAlert != .none {
             let notification = UNMutableNotificationContent()
             notification.title = LocalizedStrings.newTransaction
             notification.body = "\(LocalizedStrings.youReceived) \(tx!.dcrAmount.round(8).description) DCR"
@@ -102,9 +102,7 @@ class TransactionNotification: NSObject {
 
 extension TransactionNotification: DcrlibwalletTxAndBlockNotificationListenerProtocol {
     func onTransaction(_ transaction: String?) {
-        if Settings.incomingNotificationEnabled {
-            self.newTxNotification(transaction)
-        }
+        self.newTxNotification(transaction)
     }
     
     func onBlockAttached(_ walletID: Int, blockHeight: Int32) {


### PR DESCRIPTION
This PR fixes transaction notifications per wallet
it requires https://github.com/raedahgroup/dcrlibwallet/pull/130
closes #672 
<img height="500" alt="Screenshot 2020-05-02 at 19 35 42" src="https://user-images.githubusercontent.com/794430/80872840-739aa680-8cac-11ea-81f4-641659dd0f07.png">